### PR TITLE
Fix class loader issue for notifications response

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -72,7 +72,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun createNotificationConfig(
         client: NodeClient,
         request: CreateNotificationConfigRequest,
@@ -91,7 +90,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun updateNotificationConfig(
         client: NodeClient,
         request: UpdateNotificationConfigRequest,
@@ -110,7 +108,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun deleteNotificationConfig(
         client: NodeClient,
         request: DeleteNotificationConfigRequest,
@@ -129,7 +126,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getNotificationConfig(
         client: NodeClient,
         request: GetNotificationConfigRequest,
@@ -148,7 +144,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getNotificationEvent(
         client: NodeClient,
         request: GetNotificationEventRequest,
@@ -167,7 +162,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getPluginFeatures(
         client: NodeClient,
         request: GetPluginFeaturesRequest,
@@ -186,7 +180,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getFeatureChannelList(
         client: NodeClient,
         request: GetFeatureChannelListRequest,
@@ -207,7 +200,6 @@ object NotificationsPluginInterface {
      * @param channelIds The list of channel ids to send message to.
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun sendNotification(
         client: NodeClient,
         eventSource: EventSource,

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -232,8 +232,7 @@ object NotificationsPluginInterface {
      * the response object.
      */
     @Suppress("UNCHECKED_CAST")
-    private fun <Response : BaseResponse>
-            wrapActionListener(
+    private fun <Response : BaseResponse> wrapActionListener(
         listener: ActionListener<Response>,
         recreate: (Writeable) -> Response
     ): ActionListener<Response> {

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -27,6 +27,7 @@
 package org.opensearch.commons.notifications
 
 import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
@@ -56,6 +57,7 @@ import org.opensearch.commons.notifications.action.UpdateNotificationConfigRespo
 import org.opensearch.commons.notifications.model.ChannelMessage
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.utils.SecureClientWrapper
+import org.opensearch.commons.utils.recreateObject
 
 /**
  * All the transport action plugin interfaces for the Notification plugin
@@ -68,6 +70,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun createNotificationConfig(
         client: NodeClient,
         request: CreateNotificationConfigRequest,
@@ -76,7 +79,16 @@ object NotificationsPluginInterface {
         client.execute(
             CREATE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? CreateNotificationConfigResponse ?:
+                    recreateObject(response) { CreateNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<CreateNotificationConfigResponse>
         )
     }
 
@@ -86,6 +98,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun updateNotificationConfig(
         client: NodeClient,
         request: UpdateNotificationConfigRequest,
@@ -94,7 +107,16 @@ object NotificationsPluginInterface {
         client.execute(
             UPDATE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? UpdateNotificationConfigResponse ?:
+                    recreateObject(response) { UpdateNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<UpdateNotificationConfigResponse>
         )
     }
 
@@ -104,6 +126,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun deleteNotificationConfig(
         client: NodeClient,
         request: DeleteNotificationConfigRequest,
@@ -112,7 +135,16 @@ object NotificationsPluginInterface {
         client.execute(
             DELETE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? DeleteNotificationConfigResponse ?:
+                    recreateObject(response) { DeleteNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<DeleteNotificationConfigResponse>
         )
     }
 
@@ -122,6 +154,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getNotificationConfig(
         client: NodeClient,
         request: GetNotificationConfigRequest,
@@ -130,7 +163,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetNotificationConfigResponse ?:
+                    recreateObject(response) { GetNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetNotificationConfigResponse>
         )
     }
 
@@ -140,6 +182,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getNotificationEvent(
         client: NodeClient,
         request: GetNotificationEventRequest,
@@ -148,7 +191,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_NOTIFICATION_EVENT_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetNotificationEventResponse ?:
+                    recreateObject(response) { GetNotificationEventResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetNotificationEventResponse>
         )
     }
 
@@ -158,6 +210,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getPluginFeatures(
         client: NodeClient,
         request: GetPluginFeaturesRequest,
@@ -166,7 +219,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_PLUGIN_FEATURES_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetPluginFeaturesResponse ?:
+                    recreateObject(response) { GetPluginFeaturesResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetPluginFeaturesResponse>
         )
     }
 
@@ -176,6 +238,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getFeatureChannelList(
         client: NodeClient,
         request: GetFeatureChannelListRequest,
@@ -184,7 +247,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_FEATURE_CHANNEL_LIST_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetFeatureChannelListResponse ?:
+                    recreateObject(response) { GetFeatureChannelListResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetFeatureChannelListResponse>
         )
     }
 
@@ -196,6 +268,7 @@ object NotificationsPluginInterface {
      * @param channelIds The list of channel ids to send message to.
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun sendNotification(
         client: NodeClient,
         eventSource: EventSource,
@@ -209,7 +282,16 @@ object NotificationsPluginInterface {
         wrapper.execute(
             SEND_NOTIFICATION_ACTION_TYPE,
             SendNotificationRequest(eventSource, channelMessage, channelIds, threadContext),
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? SendNotificationResponse ?:
+                    recreateObject(response) { SendNotificationResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<SendNotificationResponse>
         )
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -81,10 +81,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? CreateNotificationConfigResponse ?:
-                    recreateObject(response) { CreateNotificationConfigResponse(it) }
+                    val recreated = response as? CreateNotificationConfigResponse
+                        ?: recreateObject(response) { CreateNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -109,10 +110,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? UpdateNotificationConfigResponse ?:
-                    recreateObject(response) { UpdateNotificationConfigResponse(it) }
+                    val recreated = response as? UpdateNotificationConfigResponse
+                        ?: recreateObject(response) { UpdateNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -137,10 +139,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? DeleteNotificationConfigResponse ?:
-                    recreateObject(response) { DeleteNotificationConfigResponse(it) }
+                    val recreated = response as? DeleteNotificationConfigResponse
+                        ?: recreateObject(response) { DeleteNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -165,10 +168,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetNotificationConfigResponse ?:
-                    recreateObject(response) { GetNotificationConfigResponse(it) }
+                    val recreated = response as? GetNotificationConfigResponse
+                        ?: recreateObject(response) { GetNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -193,10 +197,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetNotificationEventResponse ?:
-                    recreateObject(response) { GetNotificationEventResponse(it) }
+                    val recreated = response as? GetNotificationEventResponse
+                        ?: recreateObject(response) { GetNotificationEventResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -221,10 +226,12 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetPluginFeaturesResponse ?:
-                    recreateObject(response) { GetPluginFeaturesResponse(it) }
+                    val recreated = response as? GetPluginFeaturesResponse ?: recreateObject(response) {
+                        GetPluginFeaturesResponse(it)
+                    }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -249,10 +256,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetFeatureChannelListResponse ?:
-                    recreateObject(response) { GetFeatureChannelListResponse(it) }
+                    val recreated = response as? GetFeatureChannelListResponse
+                        ?: recreateObject(response) { GetFeatureChannelListResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -284,10 +292,11 @@ object NotificationsPluginInterface {
             SendNotificationRequest(eventSource, channelMessage, channelIds, threadContext),
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? SendNotificationResponse ?:
-                    recreateObject(response) { SendNotificationResponse(it) }
+                    val recreated = response as? SendNotificationResponse
+                        ?: recreateObject(response) { SendNotificationResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
fix from @dai-chen:
Recreate the response object from `ActionResponse` as specific notifications response in notifications plugin interface to avoid classloader issue when passing response between plugins
 
### Issues Resolved
#37 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
