### PR TITLE
[Notification] add method type in CustomWebhook data model

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/HttpMethodType.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/HttpMethodType.kt
@@ -1,0 +1,36 @@
+package org.opensearch.commons.notifications.model
+
+import org.opensearch.commons.utils.EnumParser
+
+enum class HttpMethodType(val tag: String) {
+    POST("POST") {
+        override fun toString(): String {
+            return tag
+        }
+    },
+    PUT("PUT") {
+        override fun toString(): String {
+            return tag
+        }
+    },
+    PATCH("PATCH") {
+        override fun toString(): String {
+            return tag
+        }
+    };
+
+    companion object {
+        private val tagMap = values().associateBy { it.tag }
+
+        val enumParser = EnumParser { fromTagOrDefault(it) }
+
+        /**
+         * Get HttpMethodType from tag or POST if not found
+         * @param tag the tag
+         * @return MethodType corresponding to tag. POST if invalid tag.
+         */
+        fun fromTagOrDefault(tag: String): HttpMethodType {
+            return tagMap[tag] ?: POST
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
@@ -46,7 +46,11 @@ internal class WebhookTests {
 
     @Test
     fun `Webhook serialize and deserialize using json object should be equal`() {
-        val sampleWebhook = Webhook("https://domain.com/sample_url#1234567890", mapOf(Pair("key", "value")))
+        val sampleWebhook = Webhook(
+            "https://domain.com/sample_url#1234567890",
+            mapOf(Pair("key", "value")),
+            HttpMethodType.PUT
+        )
         val jsonString = getJsonString(sampleWebhook)
         val recreatedObject = createObjectFromJsonString(jsonString) { Webhook.parse(it) }
         assertEquals(sampleWebhook, recreatedObject)
@@ -54,13 +58,18 @@ internal class WebhookTests {
 
     @Test
     fun `Webhook should deserialize json object using parser`() {
-        val sampleWebhook = Webhook("https://domain.com/sample_url#1234567890", mapOf(Pair("key", "value")))
+        val sampleWebhook = Webhook(
+            "https://domain.com/sample_url#1234567890",
+            mapOf(Pair("key", "value")),
+            HttpMethodType.PATCH
+        )
         val jsonString = """
             {
                 "url":"${sampleWebhook.url}",
                 "header_params":{
                     "key":"value"
-                }
+                },
+                "method":"PATCH"
             }
         """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { Webhook.parse(it) }


### PR DESCRIPTION
Signed-off-by: Zhongnan Su <szhongna@amazon.com>

### Description
- Add `method` field in webhook data model to accept `PUT`, `POST`, `PATCH` 
 
### Issues Resolved
data-model part of https://github.com/opensearch-project/notifications/issues/219
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
