### PR TITLE
Fix class loader issue for notifications response

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -72,7 +72,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun createNotificationConfig(
         client: NodeClient,
         request: CreateNotificationConfigRequest,
@@ -91,7 +90,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun updateNotificationConfig(
         client: NodeClient,
         request: UpdateNotificationConfigRequest,
@@ -110,7 +108,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun deleteNotificationConfig(
         client: NodeClient,
         request: DeleteNotificationConfigRequest,
@@ -129,7 +126,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getNotificationConfig(
         client: NodeClient,
         request: GetNotificationConfigRequest,
@@ -148,7 +144,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getNotificationEvent(
         client: NodeClient,
         request: GetNotificationEventRequest,
@@ -167,7 +162,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getPluginFeatures(
         client: NodeClient,
         request: GetPluginFeaturesRequest,
@@ -186,7 +180,6 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun getFeatureChannelList(
         client: NodeClient,
         request: GetFeatureChannelListRequest,
@@ -207,7 +200,6 @@ object NotificationsPluginInterface {
      * @param channelIds The list of channel ids to send message to.
      * @param listener The listener for getting response
      */
-    @Suppress("UNCHECKED_CAST")
     fun sendNotification(
         client: NodeClient,
         eventSource: EventSource,

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -232,8 +232,7 @@ object NotificationsPluginInterface {
      * the response object.
      */
     @Suppress("UNCHECKED_CAST")
-    private fun <Response : BaseResponse>
-            wrapActionListener(
+    private fun <Response : BaseResponse> wrapActionListener(
         listener: ActionListener<Response>,
         recreate: (Writeable) -> Response
     ): ActionListener<Response> {

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -27,6 +27,7 @@
 package org.opensearch.commons.notifications
 
 import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
@@ -56,6 +57,7 @@ import org.opensearch.commons.notifications.action.UpdateNotificationConfigRespo
 import org.opensearch.commons.notifications.model.ChannelMessage
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.utils.SecureClientWrapper
+import org.opensearch.commons.utils.recreateObject
 
 /**
  * All the transport action plugin interfaces for the Notification plugin
@@ -68,6 +70,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun createNotificationConfig(
         client: NodeClient,
         request: CreateNotificationConfigRequest,
@@ -76,7 +79,16 @@ object NotificationsPluginInterface {
         client.execute(
             CREATE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? CreateNotificationConfigResponse ?:
+                    recreateObject(response) { CreateNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<CreateNotificationConfigResponse>
         )
     }
 
@@ -86,6 +98,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun updateNotificationConfig(
         client: NodeClient,
         request: UpdateNotificationConfigRequest,
@@ -94,7 +107,16 @@ object NotificationsPluginInterface {
         client.execute(
             UPDATE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? UpdateNotificationConfigResponse ?:
+                    recreateObject(response) { UpdateNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<UpdateNotificationConfigResponse>
         )
     }
 
@@ -104,6 +126,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun deleteNotificationConfig(
         client: NodeClient,
         request: DeleteNotificationConfigRequest,
@@ -112,7 +135,16 @@ object NotificationsPluginInterface {
         client.execute(
             DELETE_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? DeleteNotificationConfigResponse ?:
+                    recreateObject(response) { DeleteNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<DeleteNotificationConfigResponse>
         )
     }
 
@@ -122,6 +154,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getNotificationConfig(
         client: NodeClient,
         request: GetNotificationConfigRequest,
@@ -130,7 +163,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_NOTIFICATION_CONFIG_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetNotificationConfigResponse ?:
+                    recreateObject(response) { GetNotificationConfigResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetNotificationConfigResponse>
         )
     }
 
@@ -140,6 +182,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getNotificationEvent(
         client: NodeClient,
         request: GetNotificationEventRequest,
@@ -148,7 +191,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_NOTIFICATION_EVENT_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetNotificationEventResponse ?:
+                    recreateObject(response) { GetNotificationEventResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetNotificationEventResponse>
         )
     }
 
@@ -158,6 +210,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getPluginFeatures(
         client: NodeClient,
         request: GetPluginFeaturesRequest,
@@ -166,7 +219,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_PLUGIN_FEATURES_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetPluginFeaturesResponse ?:
+                    recreateObject(response) { GetPluginFeaturesResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetPluginFeaturesResponse>
         )
     }
 
@@ -176,6 +238,7 @@ object NotificationsPluginInterface {
      * @param request The request object
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun getFeatureChannelList(
         client: NodeClient,
         request: GetFeatureChannelListRequest,
@@ -184,7 +247,16 @@ object NotificationsPluginInterface {
         client.execute(
             GET_FEATURE_CHANNEL_LIST_ACTION_TYPE,
             request,
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? GetFeatureChannelListResponse ?:
+                    recreateObject(response) { GetFeatureChannelListResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<GetFeatureChannelListResponse>
         )
     }
 
@@ -196,6 +268,7 @@ object NotificationsPluginInterface {
      * @param channelIds The list of channel ids to send message to.
      * @param listener The listener for getting response
      */
+    @Suppress("UNCHECKED_CAST")
     fun sendNotification(
         client: NodeClient,
         eventSource: EventSource,
@@ -209,7 +282,16 @@ object NotificationsPluginInterface {
         wrapper.execute(
             SEND_NOTIFICATION_ACTION_TYPE,
             SendNotificationRequest(eventSource, channelMessage, channelIds, threadContext),
-            listener
+            object : ActionListener<ActionResponse> {
+                override fun onResponse(response: ActionResponse) {
+                    val recreated = response as? SendNotificationResponse ?:
+                    recreateObject(response) { SendNotificationResponse(it) }
+                    listener.onResponse(recreated)
+                }
+                override fun onFailure(exception: java.lang.Exception) {
+                    listener.onFailure(exception)
+                }
+            } as ActionListener<SendNotificationResponse>
         )
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -81,10 +81,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? CreateNotificationConfigResponse ?:
-                    recreateObject(response) { CreateNotificationConfigResponse(it) }
+                    val recreated = response as? CreateNotificationConfigResponse
+                        ?: recreateObject(response) { CreateNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -109,10 +110,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? UpdateNotificationConfigResponse ?:
-                    recreateObject(response) { UpdateNotificationConfigResponse(it) }
+                    val recreated = response as? UpdateNotificationConfigResponse
+                        ?: recreateObject(response) { UpdateNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -137,10 +139,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? DeleteNotificationConfigResponse ?:
-                    recreateObject(response) { DeleteNotificationConfigResponse(it) }
+                    val recreated = response as? DeleteNotificationConfigResponse
+                        ?: recreateObject(response) { DeleteNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -165,10 +168,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetNotificationConfigResponse ?:
-                    recreateObject(response) { GetNotificationConfigResponse(it) }
+                    val recreated = response as? GetNotificationConfigResponse
+                        ?: recreateObject(response) { GetNotificationConfigResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -193,10 +197,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetNotificationEventResponse ?:
-                    recreateObject(response) { GetNotificationEventResponse(it) }
+                    val recreated = response as? GetNotificationEventResponse
+                        ?: recreateObject(response) { GetNotificationEventResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -221,10 +226,12 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetPluginFeaturesResponse ?:
-                    recreateObject(response) { GetPluginFeaturesResponse(it) }
+                    val recreated = response as? GetPluginFeaturesResponse ?: recreateObject(response) {
+                        GetPluginFeaturesResponse(it)
+                    }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -249,10 +256,11 @@ object NotificationsPluginInterface {
             request,
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? GetFeatureChannelListResponse ?:
-                    recreateObject(response) { GetFeatureChannelListResponse(it) }
+                    val recreated = response as? GetFeatureChannelListResponse
+                        ?: recreateObject(response) { GetFeatureChannelListResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }
@@ -284,10 +292,11 @@ object NotificationsPluginInterface {
             SendNotificationRequest(eventSource, channelMessage, channelIds, threadContext),
             object : ActionListener<ActionResponse> {
                 override fun onResponse(response: ActionResponse) {
-                    val recreated = response as? SendNotificationResponse ?:
-                    recreateObject(response) { SendNotificationResponse(it) }
+                    val recreated = response as? SendNotificationResponse
+                        ?: recreateObject(response) { SendNotificationResponse(it) }
                     listener.onResponse(recreated)
                 }
+
                 override fun onFailure(exception: java.lang.Exception) {
                     listener.onFailure(exception)
                 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -218,7 +218,7 @@ object NotificationsPluginInterface {
     }
 
     /**
-     * Wrap action listener on concrete response class by another another on ActionResponse.
+     * Wrap action listener on concrete response class by a new created one on ActionResponse.
      * This is required because the response may be loaded by different classloader across plugins.
      * The onResponse(ActionResponse) avoids type cast exception and give a chance to recreate
      * the response object.

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -1,3 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
 package org.opensearch.commons.notifications
 
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -192,7 +192,8 @@ internal class NotificationsPluginInterfaceTests {
                 Pair("FeatureKey1", "FeatureValue1"),
                 Pair("FeatureKey2", "FeatureValue2"),
                 Pair("FeatureKey3", "FeatureValue3")
-            ))
+            )
+        )
         val listener: ActionListener<GetPluginFeaturesResponse> =
             mock(ActionListener::class.java) as ActionListener<GetPluginFeaturesResponse>
 
@@ -253,8 +254,8 @@ internal class NotificationsPluginInterfaceTests {
         }.`when`(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.sendNotification(
-            client, notificationInfo, channelMessage, listOf("channelId1", "channelId2"), listener)
+            client, notificationInfo, channelMessage, listOf("channelId1", "channelId2"), listener
+        )
         verify(listener, times(1)).onResponse(eq(response))
     }
-
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -10,6 +10,7 @@
  */
 package org.opensearch.commons.notifications
 
+import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Answers
@@ -76,7 +77,7 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<CreateNotificationConfigResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.createNotificationConfig(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -92,7 +93,7 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<UpdateNotificationConfigResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.updateNotificationConfig(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -108,7 +109,7 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<DeleteNotificationConfigResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.deleteNotificationConfig(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -116,31 +117,15 @@ internal class NotificationsPluginInterfaceTests {
 
     @Test
     fun getNotificationConfig() {
-        val sampleSlack = Slack("https://domain.com/sample_url#1234567890")
-        val sampleConfig = NotificationConfig(
-            "name",
-            "description",
-            ConfigType.SLACK,
-            EnumSet.of(Feature.REPORTS),
-            configData = sampleSlack
-        )
-        val configInfo = NotificationConfigInfo(
-            "config_id",
-            Instant.now(),
-            Instant.now(),
-            "tenant",
-            sampleConfig
-        )
-
         val request = mock(GetNotificationConfigRequest::class.java)
-        val response = GetNotificationConfigResponse(NotificationConfigSearchResult(configInfo))
+        val response = mockGetNotificationConfigResponse()
         val listener: ActionListener<GetNotificationConfigResponse> =
             mock(ActionListener::class.java) as ActionListener<GetNotificationConfigResponse>
 
         doAnswer {
             (it.getArgument(2) as ActionListener<GetNotificationConfigResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.getNotificationConfig(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -148,36 +133,15 @@ internal class NotificationsPluginInterfaceTests {
 
     @Test
     fun getNotificationEvent() {
-        val sampleEventSource = EventSource(
-            "title",
-            "reference_id",
-            Feature.ALERTING,
-            severity = SeverityType.INFO
-        )
-        val sampleStatus = EventStatus(
-            "config_id",
-            "name",
-            ConfigType.SLACK,
-            deliveryStatus = DeliveryStatus("404", "invalid recipient")
-        )
-        val sampleEvent = NotificationEvent(sampleEventSource, listOf(sampleStatus))
-        val eventInfo = NotificationEventInfo(
-            "event_id",
-            Instant.now(),
-            Instant.now(),
-            "tenant",
-            sampleEvent
-        )
-
         val request = mock(GetNotificationEventRequest::class.java)
-        val response = GetNotificationEventResponse(NotificationEventSearchResult(eventInfo))
+        val response = mockGetNotificationEventResponse()
         val listener: ActionListener<GetNotificationEventResponse> =
             mock(ActionListener::class.java) as ActionListener<GetNotificationEventResponse>
 
         doAnswer {
             (it.getArgument(2) as ActionListener<GetNotificationEventResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.getNotificationEvent(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -200,7 +164,7 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<GetPluginFeaturesResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.getPluginFeatures(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -223,7 +187,7 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<GetFeatureChannelListResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.getFeatureChannelList(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
@@ -251,11 +215,54 @@ internal class NotificationsPluginInterfaceTests {
         doAnswer {
             (it.getArgument(2) as ActionListener<SendNotificationResponse>)
                 .onResponse(response)
-        }.`when`(client).execute(any(ActionType::class.java), any(), any())
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.sendNotification(
             client, notificationInfo, channelMessage, listOf("channelId1", "channelId2"), listener
         )
         verify(listener, times(1)).onResponse(eq(response))
+    }
+
+    private fun mockGetNotificationConfigResponse(): GetNotificationConfigResponse {
+        val sampleSlack = Slack("https://domain.com/sample_url#1234567890")
+        val sampleConfig = NotificationConfig(
+            "name",
+            "description",
+            ConfigType.SLACK,
+            EnumSet.of(Feature.REPORTS),
+            configData = sampleSlack
+        )
+        val configInfo = NotificationConfigInfo(
+            "config_id",
+            Instant.now(),
+            Instant.now(),
+            "tenant",
+            sampleConfig
+        )
+        return GetNotificationConfigResponse(NotificationConfigSearchResult(configInfo))
+    }
+
+    private fun mockGetNotificationEventResponse(): GetNotificationEventResponse {
+        val sampleEventSource = EventSource(
+            "title",
+            "reference_id",
+            Feature.ALERTING,
+            severity = SeverityType.INFO
+        )
+        val sampleStatus = EventStatus(
+            "config_id",
+            "name",
+            ConfigType.SLACK,
+            deliveryStatus = DeliveryStatus("404", "invalid recipient")
+        )
+        val sampleEvent = NotificationEvent(sampleEventSource, listOf(sampleStatus))
+        val eventInfo = NotificationEventInfo(
+            "event_id",
+            Instant.now(),
+            Instant.now(),
+            "tenant",
+            sampleEvent
+        )
+        return GetNotificationEventResponse(NotificationEventSearchResult(eventInfo))
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -1,0 +1,70 @@
+package org.opensearch.commons.notifications
+
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.junit.jupiter.MockitoExtension
+import org.opensearch.action.ActionListener
+import org.opensearch.action.ActionType
+import org.opensearch.client.node.NodeClient
+import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
+import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
+
+@Suppress("UNCHECKED_CAST")
+@ExtendWith(MockitoExtension::class)
+internal class NotificationsPluginInterfaceTests {
+
+    @Mock
+    private lateinit var nodeClient: NodeClient
+
+    @Test
+    fun createNotificationConfig() {
+        val request = mock(CreateNotificationConfigRequest::class.java)
+        val response = CreateNotificationConfigResponse("configId")
+        val listener: ActionListener<CreateNotificationConfigResponse> =
+                mock(ActionListener::class.java) as ActionListener<CreateNotificationConfigResponse>
+
+        doAnswer {
+            (it.getArgument(2)as ActionListener<CreateNotificationConfigResponse>)
+                    .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.createNotificationConfig(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
+    }
+
+    @Test
+    fun updateNotificationConfig() {
+    }
+
+    @Test
+    fun deleteNotificationConfig() {
+    }
+
+    @Test
+    fun getNotificationConfig() {
+    }
+
+    @Test
+    fun getNotificationEvent() {
+    }
+
+    @Test
+    fun getPluginFeatures() {
+    }
+
+    @Test
+    fun getFeatureChannelList() {
+    }
+
+    @Test
+    fun sendNotification() {
+    }
+
+}

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -15,6 +15,36 @@ import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
+import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
+import org.opensearch.commons.notifications.action.DeleteNotificationConfigResponse
+import org.opensearch.commons.notifications.action.GetFeatureChannelListRequest
+import org.opensearch.commons.notifications.action.GetFeatureChannelListResponse
+import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
+import org.opensearch.commons.notifications.action.GetNotificationConfigResponse
+import org.opensearch.commons.notifications.action.GetNotificationEventRequest
+import org.opensearch.commons.notifications.action.GetNotificationEventResponse
+import org.opensearch.commons.notifications.action.GetPluginFeaturesRequest
+import org.opensearch.commons.notifications.action.GetPluginFeaturesResponse
+import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
+import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
+import org.opensearch.commons.notifications.model.ConfigType
+import org.opensearch.commons.notifications.model.DeliveryStatus
+import org.opensearch.commons.notifications.model.EventSource
+import org.opensearch.commons.notifications.model.EventStatus
+import org.opensearch.commons.notifications.model.Feature
+import org.opensearch.commons.notifications.model.FeatureChannel
+import org.opensearch.commons.notifications.model.FeatureChannelList
+import org.opensearch.commons.notifications.model.NotificationConfig
+import org.opensearch.commons.notifications.model.NotificationConfigInfo
+import org.opensearch.commons.notifications.model.NotificationConfigSearchResult
+import org.opensearch.commons.notifications.model.NotificationEvent
+import org.opensearch.commons.notifications.model.NotificationEventInfo
+import org.opensearch.commons.notifications.model.NotificationEventSearchResult
+import org.opensearch.commons.notifications.model.SeverityType
+import org.opensearch.commons.notifications.model.Slack
+import org.opensearch.rest.RestStatus
+import java.time.Instant
+import java.util.EnumSet
 
 @Suppress("UNCHECKED_CAST")
 @ExtendWith(MockitoExtension::class)
@@ -28,11 +58,11 @@ internal class NotificationsPluginInterfaceTests {
         val request = mock(CreateNotificationConfigRequest::class.java)
         val response = CreateNotificationConfigResponse("configId")
         val listener: ActionListener<CreateNotificationConfigResponse> =
-                mock(ActionListener::class.java) as ActionListener<CreateNotificationConfigResponse>
+            mock(ActionListener::class.java) as ActionListener<CreateNotificationConfigResponse>
 
         doAnswer {
-            (it.getArgument(2)as ActionListener<CreateNotificationConfigResponse>)
-                    .onResponse(response)
+            (it.getArgument(2) as ActionListener<CreateNotificationConfigResponse>)
+                .onResponse(response)
         }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.createNotificationConfig(nodeClient, request, listener)
@@ -41,26 +71,148 @@ internal class NotificationsPluginInterfaceTests {
 
     @Test
     fun updateNotificationConfig() {
+        val request = mock(UpdateNotificationConfigRequest::class.java)
+        val response = UpdateNotificationConfigResponse("configId")
+        val listener: ActionListener<UpdateNotificationConfigResponse> =
+            mock(ActionListener::class.java) as ActionListener<UpdateNotificationConfigResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<UpdateNotificationConfigResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.updateNotificationConfig(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test
     fun deleteNotificationConfig() {
+        val request = mock(DeleteNotificationConfigRequest::class.java)
+        val response = DeleteNotificationConfigResponse(mapOf(Pair("sample_config_id", RestStatus.OK)))
+        val listener: ActionListener<DeleteNotificationConfigResponse> =
+            mock(ActionListener::class.java) as ActionListener<DeleteNotificationConfigResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<DeleteNotificationConfigResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.deleteNotificationConfig(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test
     fun getNotificationConfig() {
+        val sampleSlack = Slack("https://domain.com/sample_url#1234567890")
+        val sampleConfig = NotificationConfig(
+            "name",
+            "description",
+            ConfigType.SLACK,
+            EnumSet.of(Feature.REPORTS),
+            configData = sampleSlack
+        )
+        val configInfo = NotificationConfigInfo(
+            "config_id",
+            Instant.now(),
+            Instant.now(),
+            "tenant",
+            sampleConfig
+        )
+
+        val request = mock(GetNotificationConfigRequest::class.java)
+        val response = GetNotificationConfigResponse(NotificationConfigSearchResult(configInfo))
+        val listener: ActionListener<GetNotificationConfigResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetNotificationConfigResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<GetNotificationConfigResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.getNotificationConfig(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test
     fun getNotificationEvent() {
+        val sampleEventSource = EventSource(
+            "title",
+            "reference_id",
+            Feature.ALERTING,
+            severity = SeverityType.INFO
+        )
+        val sampleStatus = EventStatus(
+            "config_id",
+            "name",
+            ConfigType.SLACK,
+            deliveryStatus = DeliveryStatus("404", "invalid recipient")
+        )
+        val sampleEvent = NotificationEvent(sampleEventSource, listOf(sampleStatus))
+        val eventInfo = NotificationEventInfo(
+            "event_id",
+            Instant.now(),
+            Instant.now(),
+            "tenant",
+            sampleEvent
+        )
+
+        val request = mock(GetNotificationEventRequest::class.java)
+        val response = GetNotificationEventResponse(NotificationEventSearchResult(eventInfo))
+        val listener: ActionListener<GetNotificationEventResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetNotificationEventResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<GetNotificationEventResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.getNotificationEvent(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test
     fun getPluginFeatures() {
+        val request = mock(GetPluginFeaturesRequest::class.java)
+        val response = GetPluginFeaturesResponse(
+            listOf("config_type_1", "config_type_2", "config_type_3"),
+            mapOf(
+                Pair("FeatureKey1", "FeatureValue1"),
+                Pair("FeatureKey2", "FeatureValue2"),
+                Pair("FeatureKey3", "FeatureValue3")
+            ))
+        val listener: ActionListener<GetPluginFeaturesResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetPluginFeaturesResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<GetPluginFeaturesResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.getPluginFeatures(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test
     fun getFeatureChannelList() {
+        val sampleConfig = FeatureChannel(
+            "config_id",
+            "name",
+            "description",
+            ConfigType.SLACK
+        )
+
+        val request = mock(GetFeatureChannelListRequest::class.java)
+        val response = GetFeatureChannelListResponse(FeatureChannelList(sampleConfig))
+        val listener: ActionListener<GetFeatureChannelListResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetFeatureChannelListResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<GetFeatureChannelListResponse>)
+                .onResponse(response)
+        }.`when`(nodeClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.getFeatureChannelList(nodeClient, request, listener)
+        verify(listener, times(1)).onResponse(eq(response))
     }
 
     @Test

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Description
Type cast error occurred when entering `ActionResponse.onResponse()`. The reason is due to different class loaders across plugins that explained in details here: https://github.com/opensearch-project/notifications/pull/223. To solve the problem in similar way, wrap the listener by a new one with only difference on generic type (which is abstract `ActionResponse` rather than concrete `XXXNotificationResponse` to delay the casting operation after recreating response object by class loaded by current plugin class loader.

The main wrapper logic is patched from this https://github.com/opensearch-project/common-utils/pull/38. This PR is focused on adding missing UT to cover all notification APIs touched.
 
### Issues Resolved
https://github.com/opensearch-project/common-utils/issues/37
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
