### PR TITLE
[Notification] remove https only restrictions on webhook url protocols

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/utils/ValidationHelpers.kt
+++ b/src/main/kotlin/org/opensearch/commons/utils/ValidationHelpers.kt
@@ -34,9 +34,6 @@ private val VALID_ID_CHARS: Set<Char> = (('a'..'z') + ('A'..'Z') + ('0'..'9') + 
 
 fun validateUrl(urlString: String) {
     require(isValidUrl(urlString)) { "Invalid URL or unsupported" }
-    val url = URL(urlString)
-    require("https" == url.protocol) // Support only HTTPS. HTTP and other protocols not supported
-    // TODO : Add hosts deny list
 }
 
 fun validateEmail(email: String) {
@@ -49,8 +46,7 @@ fun validateId(idString: String) {
 
 fun isValidUrl(urlString: String): Boolean {
     val url = URL(urlString) // throws MalformedURLException if URL is invalid
-    // TODO : Add hosts deny list
-    return ("https" == url.protocol) // Support only HTTPS. HTTP and other protocols not supported
+    return ("https" == url.protocol || "http" == url.protocol) // Support only http/https, other protocols not supported
 }
 
 /**

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/ChimeTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/ChimeTests.kt
@@ -89,11 +89,11 @@ internal class ChimeTests {
     }
 
     @Test
-    fun `Chime should throw exception when url protocol is not https`() {
+    fun `Chime should throw exception when url protocol is not https or http`() {
         assertThrows<IllegalArgumentException> {
-            Chime("http://domain.com/sample_url#1234567890")
+            Chime("ftp://domain.com/sample_url#1234567890")
         }
-        val jsonString = "{\"url\":\"http://domain.com/sample_url\"}"
+        val jsonString = "{\"url\":\"ftp://domain.com/sample_url\"}"
         assertThrows<IllegalArgumentException> {
             createObjectFromJsonString(jsonString) { Chime.parse(it) }
         }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/SlackTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/SlackTests.kt
@@ -89,11 +89,11 @@ internal class SlackTests {
     }
 
     @Test
-    fun `Slack should throw exception when url protocol is not https`() {
+    fun `Slack should throw exception when url protocol is not https or http`() {
         assertThrows<IllegalArgumentException> {
-            Slack("http://domain.com/sample_url#1234567890")
+            Slack("ftp://domain.com/sample_url#1234567890")
         }
-        val jsonString = "{\"url\":\"http://domain.com/sample_url\"}"
+        val jsonString = "{\"url\":\"ftp://domain.com/sample_url\"}"
         assertThrows<IllegalArgumentException> {
             createObjectFromJsonString(jsonString) { Slack.parse(it) }
         }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
@@ -47,7 +47,7 @@ internal class WebhookTests {
     @Test
     fun `Webhook serialize and deserialize using json object should be equal`() {
         val sampleWebhook = Webhook(
-            "https://domain.com/sample_url#1234567890",
+            "http://domain.com/sample_url#1234567890",
             mapOf(Pair("key", "value")),
             HttpMethodType.PUT
         )
@@ -105,11 +105,11 @@ internal class WebhookTests {
     }
 
     @Test
-    fun `Webhook should throw exception when url protocol is not https`() {
+    fun `Webhook should throw exception when url protocol is not https or http`() {
         assertThrows<IllegalArgumentException> {
-            Webhook("http://domain.com/sample_url#1234567890")
+            Webhook("ftp://domain.com/sample_url#1234567890")
         }
-        val jsonString = "{\"url\":\"http://domain.com/sample_url\"}"
+        val jsonString = "{\"url\":\"ftp://domain.com/sample_url\"}"
         assertThrows<IllegalArgumentException> {
             createObjectFromJsonString(jsonString) { Webhook.parse(it) }
         }


### PR DESCRIPTION
### Description
remove https only restrictions on webhook url protocols
notificatuion side change is made in this PR https://github.com/opensearch-project/notifications/pull/248
 
### Issues Resolved
https://github.com/opensearch-project/notifications/issues/232
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
