### PR TITLE
Adds legacy chime, slack, custom webhook messages, request/response f…

### DIFF
--- a/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+/**
+ * This class holds the generic parameters required for a
+ * message.
+ */
+public abstract class LegacyBaseMessage implements Writeable {
+
+    protected LegacyDestinationType destinationType;
+    protected String destinationName;
+    protected String url;
+    private String content;
+
+    LegacyBaseMessage(final LegacyDestinationType destinationType, final String destinationName, final String content) {
+        if (destinationType == null) {
+            throw new IllegalArgumentException("Channel type must be defined");
+        }
+        if (!Strings.hasLength(destinationName)) {
+            throw new IllegalArgumentException("Channel name must be defined");
+        }
+        this.destinationType = destinationType;
+        this.destinationName = destinationName;
+        this.content = content;
+    }
+
+    LegacyBaseMessage(final LegacyDestinationType destinationType, final String destinationName, final String content, final String url) {
+        this(destinationType, destinationName, content);
+        if (url == null) {
+            throw new IllegalArgumentException("url is invalid or empty");
+        }
+        this.url = url;
+    }
+
+    LegacyBaseMessage(org.opensearch.common.io.stream.StreamInput streamInput) throws IOException {
+        this.destinationType = streamInput.readEnum(LegacyDestinationType.class);
+        this.destinationName = streamInput.readString();
+        this.url = streamInput.readOptionalString();
+        this.content = streamInput.readString();
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public LegacyDestinationType getChannelType() {
+        return destinationType;
+    }
+
+    public String getChannelName() {
+        return destinationName;
+    }
+
+    public String getMessageContent() {
+        return content;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public URI getUri() {
+        return buildUri(getUrl().trim(), null, null, -1, null, null);
+    }
+
+    protected URI buildUri(String endpoint, String scheme, String host, int port, String path, Map<String, String> queryParams) {
+        try {
+            if (Strings.isNullOrEmpty(endpoint)) {
+                if (Strings.isNullOrEmpty(scheme)) {
+                    scheme = "https";
+                }
+                URIBuilder uriBuilder = new URIBuilder();
+                if (queryParams != null) {
+                    for (Map.Entry<String, String> e : queryParams.entrySet())
+                        uriBuilder.addParameter(e.getKey(), e.getValue());
+                }
+                return uriBuilder.setScheme(scheme).setHost(host).setPort(port).setPath(path).build();
+            }
+            return new URIBuilder(endpoint).build();
+        } catch (URISyntaxException exception) {
+            throw new IllegalStateException("Error creating URI");
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        streamOutput.writeEnum(destinationType);
+        streamOutput.writeString(destinationName);
+        streamOutput.writeOptionalString(url);
+        streamOutput.writeString(content);
+    }
+}

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyChimeMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyChimeMessage.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import java.io.IOException;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+
+/**
+ * This class holds the contents of an Chime message
+ */
+public class LegacyChimeMessage extends LegacyBaseMessage {
+    private final String message;
+
+    private LegacyChimeMessage(
+        final LegacyDestinationType destinationType,
+        final String destinationName,
+        final String url,
+        final String message
+    ) {
+
+        super(destinationType, destinationName, message, url);
+
+        if (LegacyDestinationType.CHIME != destinationType) {
+            throw new IllegalArgumentException("Channel Type does not match CHIME");
+        }
+
+        if (Strings.isNullOrEmpty(message)) {
+            throw new IllegalArgumentException("Message content is missing");
+        }
+
+        this.message = message;
+    }
+
+    public LegacyChimeMessage(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        this.message = super.getMessageContent();
+    }
+
+    @Override
+    public String toString() {
+        return "DestinationType: " + destinationType + ", DestinationName:" + destinationName + ", Url: " + url + ", Message: " + message;
+    }
+
+    public static class Builder {
+        private String message;
+        private final LegacyDestinationType destinationType;
+        private final String destinationName;
+        private String url;
+
+        public Builder(String destinationName) {
+            this.destinationName = destinationName;
+            this.destinationType = LegacyDestinationType.CHIME;
+        }
+
+        public LegacyChimeMessage.Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public LegacyChimeMessage.Builder withUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public LegacyChimeMessage build() {
+            return new LegacyChimeMessage(this.destinationType, this.destinationName, this.url, this.message);
+        }
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
@@ -1,0 +1,313 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+/**
+ * This class holds the content of an CustomWebhook message
+ */
+public class LegacyCustomWebhookMessage extends LegacyBaseMessage {
+
+    private final String message;
+    private final String url;
+    private final String scheme;
+    private final String host;
+    private final String method;
+    private final int port;
+    private String path;
+    private Map<String, String> queryParams;
+    private Map<String, String> headerParams;
+    private final String userName;
+    private final String password;
+
+    private LegacyCustomWebhookMessage(
+        final LegacyDestinationType destinationType,
+        final String destinationName,
+        final String url,
+        final String scheme,
+        final String host,
+        final Integer port,
+        final String path,
+        final String method,
+        final Map<String, String> queryParams,
+        final Map<String, String> headerParams,
+        final String userName,
+        final String password,
+        final String message
+    ) {
+
+        super(destinationType, destinationName, message);
+
+        if (LegacyDestinationType.CUSTOMWEBHOOK != destinationType) {
+            throw new IllegalArgumentException("Channel Type does not match CustomWebhook");
+        }
+
+        if (!Strings.isNullOrEmpty(url)) {
+            setUrl(url.trim());
+        }
+
+        if (Strings.isNullOrEmpty(message)) {
+            throw new IllegalArgumentException("Message content is missing");
+        }
+
+        this.scheme = Strings.isNullOrEmpty(scheme) ? "https" : scheme;
+        this.port = port == null ? -1 : port;
+
+        if (!Strings.isNullOrEmpty(path)) {
+            if (!path.startsWith("/")) {
+                this.path = "/" + path;
+            }
+        }
+
+        if (Strings.isNullOrEmpty(url) && Strings.isNullOrEmpty(host)) {
+            throw new IllegalArgumentException("Either fully qualified URL or host name should be provided");
+        }
+
+        if (Strings.isNullOrEmpty(method)) {
+            // Default to POST for backwards compatibility
+            this.method = "POST";
+        } else if (!HttpPost.METHOD_NAME.equals(method) && !HttpPut.METHOD_NAME.equals(method) && !HttpPatch.METHOD_NAME.equals(method)) {
+            throw new IllegalArgumentException("Invalid method supplied. Only POST, PUT and PATCH are allowed");
+        } else {
+            this.method = method;
+        }
+
+        this.message = message;
+        this.url = url;
+        this.host = host;
+        this.queryParams = queryParams;
+        this.headerParams = headerParams;
+        this.userName = userName;
+        this.password = password;
+    }
+
+    public LegacyCustomWebhookMessage(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        this.message = super.getMessageContent();
+        this.url = streamInput.readOptionalString();
+        this.scheme = streamInput.readOptionalString();
+        this.host = streamInput.readOptionalString();
+        this.method = streamInput.readOptionalString();
+        this.port = streamInput.readOptionalInt();
+        this.path = streamInput.readOptionalString();
+        if (streamInput.readBoolean()) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> queryParams = (Map<String, String>) (Map) streamInput.readMap();
+            this.queryParams = queryParams;
+        }
+        if (streamInput.readBoolean()) {
+            @SuppressWarnings("unchecked")
+            Map<String, String> headerParams = (Map<String, String>) (Map) streamInput.readMap();
+            this.headerParams = headerParams;
+        }
+        this.userName = streamInput.readOptionalString();
+        this.password = streamInput.readOptionalString();
+    }
+
+    @Override
+    public String toString() {
+        return "DestinationType: "
+            + destinationType
+            + ", DestinationName:"
+            + destinationName
+            + ", Url: "
+            + url
+            + ", scheme: "
+            + scheme
+            + ", Host: "
+            + host
+            + ", Port: "
+            + port
+            + ", Path: "
+            + path
+            + ", Method: "
+            + method
+            + ", Message: "
+            + message;
+    }
+
+    public static class Builder {
+        private String message;
+        private final LegacyDestinationType destinationType;
+        private final String destinationName;
+        private String url;
+        private String scheme;
+        private String host;
+        private Integer port;
+        private String path;
+        private String method;
+        private Map<String, String> queryParams;
+        private Map<String, String> headerParams;
+        private String userName;
+        private String password;
+
+        public Builder(String destinationName) {
+            this.destinationName = destinationName;
+            this.destinationType = LegacyDestinationType.CUSTOMWEBHOOK;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withScheme(String scheme) {
+            this.scheme = scheme;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withPort(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withPath(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withMethod(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withQueryParams(Map<String, String> queryParams) {
+            this.queryParams = queryParams;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withHeaderParams(Map<String, String> headerParams) {
+            this.headerParams = headerParams;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withUserName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage.Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public LegacyCustomWebhookMessage build() {
+            return new LegacyCustomWebhookMessage(
+                this.destinationType,
+                this.destinationName,
+                this.url,
+                this.scheme,
+                this.host,
+                this.port,
+                this.path,
+                this.method,
+                this.queryParams,
+                this.headerParams,
+                this.userName,
+                this.password,
+                this.message
+            );
+        }
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public Map<String, String> getQueryParams() {
+        return queryParams;
+    }
+
+    public Map<String, String> getHeaderParams() {
+        return headerParams;
+    }
+
+    public URI getUri() {
+        return buildUri(getUrl(), getScheme(), getHost(), getPort(), getPath(), getQueryParams());
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        super.writeTo(streamOutput);
+        streamOutput.writeOptionalString(url);
+        streamOutput.writeOptionalString(scheme);
+        streamOutput.writeOptionalString(host);
+        streamOutput.writeOptionalString(method);
+        streamOutput.writeOptionalInt(port);
+        streamOutput.writeOptionalString(path);
+        streamOutput.writeBoolean(queryParams != null);
+        if (queryParams != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> queryParams = (Map<String, Object>) (Map) this.queryParams;
+            streamOutput.writeMap(queryParams);
+        }
+        streamOutput.writeBoolean(headerParams != null);
+        if (headerParams != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> headerParams = (Map<String, Object>) (Map) this.headerParams;
+            streamOutput.writeMap(headerParams);
+        }
+        streamOutput.writeOptionalString(userName);
+        streamOutput.writeOptionalString(password);
+    }
+}

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+/**
+ * Supported legacy notification destinations for Index Management
+ */
+public enum LegacyDestinationType {
+    CHIME,
+    SLACK,
+    CUSTOMWEBHOOK
+}

--- a/src/main/java/org/opensearch/commons/destination/message/LegacySlackMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacySlackMessage.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import java.io.IOException;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+
+/**
+ * This class holds the content of an Slack message
+ */
+public class LegacySlackMessage extends LegacyBaseMessage {
+    private String message;
+
+    private LegacySlackMessage(
+        final LegacyDestinationType destinationType,
+        final String destinationName,
+        final String url,
+        final String message
+    ) {
+
+        super(destinationType, destinationName, message, url);
+
+        if (LegacyDestinationType.SLACK != destinationType) {
+            throw new IllegalArgumentException("Channel Type does not match Slack");
+        }
+
+        if (Strings.isNullOrEmpty(url)) { // add URL validation
+            throw new IllegalArgumentException("Fully qualified URL is missing/invalid: " + url);
+        }
+
+        if (Strings.isNullOrEmpty(message)) {
+            throw new IllegalArgumentException("Message content is missing");
+        }
+
+        this.message = message;
+    }
+
+    public LegacySlackMessage(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        this.message = super.getMessageContent();
+    }
+
+    @Override
+    public String toString() {
+        return "DestinationType: " + destinationType + ", DestinationName:" + destinationName + ", Url: " + url + ", Message: " + message;
+    }
+
+    public static class Builder {
+        private String message;
+        private LegacyDestinationType destinationType;
+        private String destinationName;
+        private String url;
+
+        public Builder(String channelName) {
+            this.destinationName = channelName;
+            this.destinationType = LegacyDestinationType.SLACK;
+        }
+
+        public LegacySlackMessage.Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public LegacySlackMessage.Builder withUrl(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public LegacySlackMessage build() {
+            return new LegacySlackMessage(this.destinationType, this.destinationName, this.url, this.message);
+        }
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/org/opensearch/commons/destination/response/LegacyBaseResponse.java
+++ b/src/main/java/org/opensearch/commons/destination/response/LegacyBaseResponse.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.response;
+
+import java.io.IOException;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+
+/**
+ * This class holds the generic response attributes
+ */
+public abstract class LegacyBaseResponse implements Writeable {
+    protected Integer statusCode;
+
+    LegacyBaseResponse(final Integer statusCode) {
+        if (statusCode == null) {
+            throw new IllegalArgumentException("status code is invalid");
+        }
+        this.statusCode = statusCode;
+    }
+
+    public LegacyBaseResponse(StreamInput streamInput) throws IOException {
+        this.statusCode = streamInput.readInt();
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        streamOutput.writeInt(statusCode);
+    }
+}

--- a/src/main/java/org/opensearch/commons/destination/response/LegacyDestinationResponse.java
+++ b/src/main/java/org/opensearch/commons/destination/response/LegacyDestinationResponse.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.response;
+
+import java.io.IOException;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+/**
+ * This class is a place holder for destination response metadata
+ */
+public class LegacyDestinationResponse extends LegacyBaseResponse {
+
+    private final String responseContent;
+
+    private LegacyDestinationResponse(final String responseString, final Integer statusCode) {
+        super(statusCode);
+        if (responseString == null) {
+            throw new IllegalArgumentException("Response is missing");
+        }
+        this.responseContent = responseString;
+    }
+
+    public LegacyDestinationResponse(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        this.responseContent = streamInput.readString();
+    }
+
+    public static class Builder {
+        private String responseContent;
+        private Integer statusCode;
+
+        public LegacyDestinationResponse.Builder withResponseContent(String responseContent) {
+            this.responseContent = responseContent;
+            return this;
+        }
+
+        public LegacyDestinationResponse.Builder withStatusCode(Integer statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public LegacyDestinationResponse build() {
+            return new LegacyDestinationResponse(responseContent, statusCode);
+        }
+    }
+
+    public String getResponseContent() {
+        return this.responseContent;
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        super.writeTo(streamOutput);
+        streamOutput.writeString(responseContent);
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.commons.notifications.action
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.commons.destination.message.LegacyBaseMessage
+import org.opensearch.commons.destination.message.LegacyChimeMessage
+import org.opensearch.commons.destination.message.LegacyCustomWebhookMessage
+import org.opensearch.commons.destination.message.LegacyDestinationType
+import org.opensearch.commons.destination.message.LegacySlackMessage
+import org.opensearch.commons.notifications.model.Feature
+import java.io.IOException
+
+/**
+ * Action Request to publish notification. This is a legacy implementation.
+ * This should not be used going forward, instead use [SendNotificationRequest].
+ */
+class LegacyPublishNotificationRequest : ActionRequest {
+    val baseMessage: LegacyBaseMessage
+    val feature: Feature
+
+    companion object {
+        /**
+         * reader to create instance of class from writable.
+         */
+        val reader = Writeable.Reader { LegacyPublishNotificationRequest(it) }
+    }
+
+    /**
+     * constructor for creating the class
+     * @param baseMessage the base message to send
+     * @param feature the feature that is trying to use this request
+     */
+    constructor(
+        baseMessage: LegacyBaseMessage,
+        feature: Feature
+    ) {
+        this.baseMessage = baseMessage
+        this.feature = feature
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Throws(IOException::class)
+    constructor(input: StreamInput) : super(input) {
+        baseMessage = when (requireNotNull(input.readEnum(LegacyDestinationType::class.java)) { "Destination type cannot be null" }) {
+            LegacyDestinationType.CHIME -> LegacyChimeMessage(input)
+            LegacyDestinationType.CUSTOMWEBHOOK -> LegacyCustomWebhookMessage(input)
+            LegacyDestinationType.SLACK -> LegacySlackMessage(input)
+        }
+        feature = input.readEnum(Feature::class.java)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Throws(IOException::class)
+    override fun writeTo(output: StreamOutput) {
+        super.writeTo(output)
+        output.writeEnum(baseMessage.channelType)
+        baseMessage.writeTo(output)
+        output.writeEnum(feature)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun validate(): ActionRequestValidationException? = null
+}

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationResponse.kt
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.commons.notifications.action
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.io.stream.Writeable
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.commons.destination.response.LegacyDestinationResponse
+import java.io.IOException
+
+/**
+ * Action Response for legacy publish notification.
+ */
+class LegacyPublishNotificationResponse : BaseResponse {
+    val destinationResponse: LegacyDestinationResponse
+
+    companion object {
+        /**
+         * reader to create instance of class from writable.
+         */
+        val reader = Writeable.Reader { LegacyPublishNotificationResponse(it) }
+    }
+
+    /**
+     * constructor for creating the class
+     * @param destinationResponse the response of the published notification
+     */
+    constructor(destinationResponse: LegacyDestinationResponse) {
+        this.destinationResponse = destinationResponse
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Throws(IOException::class)
+    constructor(input: StreamInput) : super(input) {
+        destinationResponse = LegacyDestinationResponse(input)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Throws(IOException::class)
+    override fun writeTo(output: StreamOutput) {
+        destinationResponse.writeTo(output)
+    }
+
+    // This class is only used across transport wire and does not need to implement toXContent
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
@@ -73,6 +73,12 @@ object NotificationsActions {
     const val SEND_NOTIFICATION_NAME = "cluster:admin/opensearch/notifications/feature/send"
 
     /**
+     * Publish legacy notification message. Internal only - Inter plugin communication.
+     * Only for the Index Management plugin.
+     */
+    const val LEGACY_PUBLISH_NOTIFICATION_NAME = "cluster:admin/opensearch/notifications/feature/publish"
+
+    /**
      * Create notification configuration transport action type.
      */
     val CREATE_NOTIFICATION_CONFIG_ACTION_TYPE =
@@ -119,4 +125,11 @@ object NotificationsActions {
      */
     val SEND_NOTIFICATION_ACTION_TYPE =
         ActionType(SEND_NOTIFICATION_NAME, ::SendNotificationResponse)
+
+    /**
+     * Send legacy notification transport action type. Internal only - Inter plugin communication.
+     * Only for the Index Management plugin.
+     */
+    val LEGACY_PUBLISH_NOTIFICATION_ACTION_TYPE =
+        ActionType(LEGACY_PUBLISH_NOTIFICATION_NAME, ::LegacyPublishNotificationResponse)
 }

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyChimeMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyChimeMessageTest.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class LegacyChimeMessageTest {
+
+    @Test
+    public void testBuildingLegacyChimeMessage() {
+        LegacyChimeMessage message = new LegacyChimeMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+
+        assertEquals("custom_webhook", message.destinationName);
+        assertEquals(LegacyDestinationType.CHIME, message.destinationType);
+        assertEquals("Hello world", message.getMessageContent());
+        assertEquals("https://amazon.com", message.url);
+    }
+
+    @Test
+    public void testRoundTrippingLegacyChimeMessage() throws IOException {
+        LegacyChimeMessage message = new LegacyChimeMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        message.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacyChimeMessage newMessage = new LegacyChimeMessage(in);
+
+        assertEquals(newMessage.destinationName, message.destinationName);
+        assertEquals(newMessage.destinationType, message.destinationType);
+        assertEquals(newMessage.getMessageContent(), message.getMessageContent());
+        assertEquals(newMessage.url, message.url);
+    }
+
+    @Test
+    public void testContentMissingMessage() {
+        try {
+            new LegacyChimeMessage.Builder("custom_webhook").withUrl("https://amazon.com").build();
+            fail("Building legacy chime message without message should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Message content is missing", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUrlMissingMessage() {
+        try {
+            new LegacyChimeMessage.Builder("custom_webhook").withMessage("Hello world").build();
+            fail("Building legacy chime message without url should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("url is invalid or empty", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingDestinationName() {
+        try {
+            new LegacyChimeMessage.Builder(null).withMessage("Hello world").withUrl("https://amazon.com").build();
+            fail("Building legacy chime message with null destination name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Channel name must be defined", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
@@ -1,0 +1,186 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class LegacyCustomWebhookMessageTest {
+
+    @Test
+    public void testBuildingLegacyCustomWebhookMessage() {
+        LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+
+        assertEquals("custom_webhook", message.destinationName);
+        assertEquals(LegacyDestinationType.CUSTOMWEBHOOK, message.destinationType);
+        assertEquals("Hello world", message.getMessageContent());
+        assertEquals("https://amazon.com", message.getUrl());
+    }
+
+    @Test
+    public void testRoundTrippingLegacyCustomWebhookMessageWithUrl() throws IOException {
+        LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        message.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacyCustomWebhookMessage newMessage = new LegacyCustomWebhookMessage(in);
+
+        assertEquals(newMessage.destinationName, message.destinationName);
+        assertEquals(newMessage.destinationType, message.destinationType);
+        assertEquals(newMessage.getMessageContent(), message.getMessageContent());
+        assertEquals(newMessage.getUrl(), message.getUrl());
+    }
+
+    @Test
+    public void testRoundTrippingLegacyCustomWebhookMessageWithHost() throws IOException {
+        Map<String, String> queryParams = new HashMap<String, String>();
+        queryParams.put("token", "sometoken");
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("x-token", "sometoken");
+        LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withHost("hooks.chime.aws")
+            .withPath("incomingwebhooks/abc")
+            .withMethod(HttpPost.METHOD_NAME)
+            .withQueryParams(queryParams)
+            .withHeaderParams(headers)
+            .withPort(8000)
+            .withScheme("https")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        message.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacyCustomWebhookMessage newMessage = new LegacyCustomWebhookMessage(in);
+
+        assertEquals(newMessage.destinationName, message.destinationName);
+        assertEquals(newMessage.destinationType, message.destinationType);
+        assertEquals(newMessage.getMessageContent(), message.getMessageContent());
+        assertEquals(newMessage.getHost(), message.getHost());
+        assertEquals(newMessage.getMethod(), message.getMethod());
+        assertEquals(newMessage.getPath(), message.getPath());
+        assertEquals(newMessage.getQueryParams(), message.getQueryParams());
+        assertEquals(newMessage.getHeaderParams(), message.getHeaderParams());
+        assertEquals(newMessage.getPort(), message.getPort());
+        assertEquals(newMessage.getScheme(), message.getScheme());
+    }
+
+    @Test
+    public void testContentMissingMessage() {
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook").withUrl("https://amazon.com").build();
+            fail("Building legacy custom webhook message without message should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Message content is missing", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingDestinationName() {
+        try {
+            new LegacyCustomWebhookMessage.Builder(null).withMessage("Hello world").withUrl("https://amazon.com").build();
+            fail("Building legacy custom webhook message with null destination name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Channel name must be defined", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnsupportedHttpMethods() {
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook")
+                .withMessage("Hello world")
+                .withUrl("https://amazon.com")
+                .withMethod(HttpGet.METHOD_NAME)
+                .build();
+            fail("Building legacy custom webhook message with unsupported http methods should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid method supplied. Only POST, PUT and PATCH are allowed", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testURLandHostNameMissingOrEmpty() {
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook").withMessage("Hello world").withMethod(HttpGet.METHOD_NAME).build();
+            fail("Building legacy custom webhook message missing or empty url and host name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Either fully qualified URL or host name should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook")
+                .withMessage("Hello world")
+                .withUrl("")
+                .withMethod(HttpGet.METHOD_NAME)
+                .build();
+            fail("Building legacy custom webhook message with missing or empty url and host name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Either fully qualified URL or host name should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook")
+                .withMessage("Hello world")
+                .withHost("")
+                .withMethod(HttpGet.METHOD_NAME)
+                .build();
+            fail("Building legacy custom webhook message with missing or empty url and host name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Either fully qualified URL or host name should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyCustomWebhookMessage.Builder("custom_webhook")
+                .withMessage("Hello world")
+                .withUrl("")
+                .withHost("")
+                .withMethod(HttpGet.METHOD_NAME)
+                .build();
+            fail("Building legacy custom webhook message with missing or empty url and host name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Either fully qualified URL or host name should be provided", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/opensearch/commons/destination/message/LegacySlackMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacySlackMessageTest.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class LegacySlackMessageTest {
+
+    @Test
+    public void testBuildingLegacySlackMessage() {
+        LegacySlackMessage message = new LegacySlackMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+
+        assertEquals("custom_webhook", message.destinationName);
+        assertEquals(LegacyDestinationType.SLACK, message.destinationType);
+        assertEquals("Hello world", message.getMessageContent());
+        assertEquals("https://amazon.com", message.url);
+    }
+
+    @Test
+    public void testRoundTrippingLegacySlackMessage() throws IOException {
+        LegacySlackMessage message = new LegacySlackMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://amazon.com")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        message.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacySlackMessage newMessage = new LegacySlackMessage(in);
+
+        assertEquals(newMessage.destinationName, message.destinationName);
+        assertEquals(newMessage.destinationType, message.destinationType);
+        assertEquals(newMessage.getMessageContent(), message.getMessageContent());
+        assertEquals(newMessage.url, message.url);
+    }
+
+    @Test
+    public void testContentMissingMessage() {
+        try {
+            new LegacySlackMessage.Builder("custom_webhook").withUrl("https://amazon.com").build();
+            fail("Building legacy slack message without message should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Message content is missing", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUrlMissingMessage() {
+        try {
+            new LegacySlackMessage.Builder("custom_webhook").withMessage("Hello world").build();
+            fail("Building legacy slack message without url should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("url is invalid or empty", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingDestinationName() {
+        try {
+            new LegacySlackMessage.Builder(null).withMessage("Hello world").withUrl("https://amazon.com").build();
+            fail("Building legacy slack message with null destination name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Channel name must be defined", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUrlEmptyMessage() {
+        try {
+            new LegacySlackMessage.Builder("custom_webhook").withMessage("Hello world").withUrl("").build();
+            fail("Building legacy slack message with empty url should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Fully qualified URL is missing/invalid: ", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/org/opensearch/commons/destination/response/LegacyDestinationResponseTest.java
+++ b/src/test/java/org/opensearch/commons/destination/response/LegacyDestinationResponseTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.commons.destination.response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class LegacyDestinationResponseTest {
+
+    @Test
+    public void testBuildingLegacyDestinationResponse() {
+        LegacyDestinationResponse res = new LegacyDestinationResponse.Builder()
+            .withStatusCode(200)
+            .withResponseContent("Hello world")
+            .build();
+
+        assertEquals(200, res.statusCode);
+        assertEquals("Hello world", res.getResponseContent());
+    }
+
+    @Test
+    public void testRoundTrippingLegacyDestinationResponse() throws IOException {
+        LegacyDestinationResponse res = new LegacyDestinationResponse.Builder()
+            .withStatusCode(200)
+            .withResponseContent("Hello world")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        res.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacyDestinationResponse newRes = new LegacyDestinationResponse(in);
+
+        assertEquals(res.statusCode, newRes.statusCode, "Round tripping doesn't work");
+        assertEquals(res.getResponseContent(), newRes.getResponseContent(), "Round tripping doesn't work");
+    }
+
+    @Test
+    public void testMissingLegacyDestinationResponse() {
+        try {
+            new LegacyDestinationResponse.Builder().withStatusCode(200).build();
+            fail("Creating LegacyDestinationResponse without response content should fail");
+        } catch (IllegalArgumentException ignored) {}
+    }
+
+    @Test
+    public void testMissingLegacyDestinationStatusCode() {
+        try {
+            new LegacyDestinationResponse.Builder().withResponseContent("Hello world").build();
+            fail("Creating LegacyDestinationResponse without status code should fail");
+        } catch (IllegalArgumentException ignored) {}
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
+import org.opensearch.commons.destination.response.LegacyDestinationResponse
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
@@ -37,6 +38,8 @@ import org.opensearch.commons.notifications.action.GetNotificationEventRequest
 import org.opensearch.commons.notifications.action.GetNotificationEventResponse
 import org.opensearch.commons.notifications.action.GetPluginFeaturesRequest
 import org.opensearch.commons.notifications.action.GetPluginFeaturesResponse
+import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequest
+import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
@@ -221,6 +224,26 @@ internal class NotificationsPluginInterfaceTests {
             client, notificationInfo, channelMessage, listOf("channelId1", "channelId2"), listener
         )
         verify(listener, times(1)).onResponse(eq(response))
+    }
+
+    @Test
+    fun publishLegacyNotification() {
+        val request = mock(LegacyPublishNotificationRequest::class.java)
+        val res = LegacyPublishNotificationResponse(LegacyDestinationResponse.Builder().withStatusCode(200).withResponseContent("Nice!").build())
+        val l: ActionListener<LegacyPublishNotificationResponse> =
+            mock(ActionListener::class.java) as ActionListener<LegacyPublishNotificationResponse>
+
+        doAnswer {
+            (it.getArgument(2) as ActionListener<LegacyPublishNotificationResponse>)
+                .onResponse(res)
+        }.whenever(client).execute(any(ActionType::class.java), any(), any())
+
+        doAnswer {
+            Feature.INDEX_MANAGEMENT
+        }.whenever(request).feature
+
+        NotificationsPluginInterface.publishLegacyNotification(client, request, l)
+        verify(l, times(1)).onResponse(eq(res))
     }
 
     private fun mockGetNotificationConfigResponse(): GetNotificationConfigResponse {

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequestTests.kt
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.commons.notifications.action
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.destination.message.LegacyChimeMessage
+import org.opensearch.commons.notifications.model.Feature
+import org.opensearch.commons.utils.recreateObject
+
+internal class LegacyPublishNotificationRequestTests {
+
+    private fun assertRequestEquals(
+        expected: LegacyPublishNotificationRequest,
+        actual: LegacyPublishNotificationRequest
+    ) {
+        assertEquals(expected.baseMessage.channelName, actual.baseMessage.channelName)
+        assertEquals(expected.baseMessage.channelType, actual.baseMessage.channelType)
+        assertEquals(expected.baseMessage.messageContent, actual.baseMessage.messageContent)
+        assertEquals(expected.baseMessage.url, actual.baseMessage.url)
+        assertEquals(expected.feature, actual.feature)
+        assertNull(actual.validate())
+    }
+
+    @Test
+    fun `publish request serialize and deserialize transport object should be equal`() {
+        val baseMessage = LegacyChimeMessage.Builder("chime_message").withMessage("Hello world").withUrl("https://amazon.com").build()
+        val request = LegacyPublishNotificationRequest(baseMessage, Feature.INDEX_MANAGEMENT)
+        val recreatedObject = recreateObject(request) { LegacyPublishNotificationRequest(it) }
+        assertRequestEquals(request, recreatedObject)
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationResponseTests.kt
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.commons.notifications.action
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.destination.response.LegacyDestinationResponse
+import org.opensearch.commons.utils.recreateObject
+
+internal class LegacyPublishNotificationResponseTests {
+
+    @Test
+    fun `Create response serialize and deserialize transport object should be equal`() {
+        val res = LegacyDestinationResponse.Builder().withStatusCode(200).withResponseContent("Hello world").build()
+        val configResponse = LegacyPublishNotificationResponse(res)
+        val recreatedObject = recreateObject(configResponse) { LegacyPublishNotificationResponse(it) }
+        assertEquals(configResponse.destinationResponse.statusCode, recreatedObject.destinationResponse.statusCode)
+        assertEquals(configResponse.destinationResponse.responseContent, recreatedObject.destinationResponse.responseContent)
+    }
+}


### PR DESCRIPTION
…or publishing legacy notifications, and method for executing transport action

Signed-off-by: Drew Baugher <46505179+dbbaughe@users.noreply.github.com>

### Description
Adds required legacy messages, request/response classes, and methods for ISM to publish a notification through the notification plugin with the old embedded types without having to create a channel first.
opensearch-project/notifications#253
 
### Issues Resolved
https://github.com/opensearch-project/common-utils/issues/44

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
