### PR TITLE
Bumping common-utils to build with OpenSearch(main) 1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: 'main'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
@@ -39,11 +39,11 @@ jobs:
       # common-utils
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.0.0
+          ./gradlew build -Dopensearch.version=1.1.0
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
     }
 
@@ -146,7 +146,7 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 
-version '1.0.0.0'
+version '1.1.0.0'
 
 publishing {
     publications {


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Bumping up common-utils to build with OpenSearch `main` which is 1.1.0.
As with the branching and release strategy for the project https://github.com/opensearch-project/.github/issues/13
Here is how it should look like:
1. Plugin/library `main` builds out of OpenSearch `main`. 
2. Plugin/library `1.x` builds out of OpenSearch `1.x`.
3. Plugin/library `1.0` builds out of OpenSearch `1.0`.

This allows us to fail fast and get ready for release.

As part of adding backwards compatibility test framework, we are developing tests as an example in Anomaly Detection which needs common-utils. 
Ref: https://github.com/opensearch-project/OpenSearch/issues/1002
Meta issue: https://github.com/opensearch-project/opensearch-build/issues/90
 
### Issues Resolved
#46 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
