### PR TITLE
Using 1.1 snapshot version for OpenSearch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,16 @@ jobs:
           ref: 'main'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
         
       # common-utils
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.1.0
+          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
     }
 


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Consuming OpenSearch 1.1 version snapshot instead of 1.1. This is required since AD consumes the 1.1 snapshot artifact (details in PR https://github.com/opensearch-project/anomaly-detection/pull/175).
 
### Issues Resolved
As part of closed issue #46.

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
