### PR TITLE
Fix and build snapshot build by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: 'main'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,17 @@ repositories {
     jcenter()
 }
 
-group 'org.opensearch.commons'
+ext {
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+}
+
+allprojects {
+    group 'org.opensearch.commons'
+    version = opensearch_version - '-SNAPSHOT' + '.0'
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
+}
 
 sourceCompatibility = 1.8
 
@@ -145,8 +155,6 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
-
-version '1.1.0.0'
 
 publishing {
     publications {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Builds snapshot by default and always matches OpenSearch version.
 
### Issues Resolved

Closes #56.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
