### PR TITLE
BugFix: Allow null values for role_arn in json parsing

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/SesAccount.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/SesAccount.kt
@@ -22,6 +22,7 @@ import org.opensearch.common.xcontent.XContentParserUtils
 import org.opensearch.commons.notifications.NotificationConstants.FROM_ADDRESS_TAG
 import org.opensearch.commons.notifications.NotificationConstants.REGION_TAG
 import org.opensearch.commons.notifications.NotificationConstants.ROLE_ARN_TAG
+import org.opensearch.commons.utils.fieldIfNotNull
 import org.opensearch.commons.utils.logger
 import org.opensearch.commons.utils.validateEmail
 import org.opensearch.commons.utils.validateIamRoleArn
@@ -74,7 +75,7 @@ data class SesAccount(
                 parser.nextToken()
                 when (fieldName) {
                     REGION_TAG -> awsRegion = parser.text()
-                    ROLE_ARN_TAG -> roleArn = parser.text()
+                    ROLE_ARN_TAG -> roleArn = parser.textOrNull()
                     FROM_ADDRESS_TAG -> fromAddress = parser.text()
                     else -> {
                         parser.skipChildren()
@@ -98,7 +99,7 @@ data class SesAccount(
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
         return builder!!.startObject()
             .field(REGION_TAG, awsRegion)
-            .field(ROLE_ARN_TAG, roleArn)
+            .fieldIfNotNull(ROLE_ARN_TAG, roleArn)
             .field(FROM_ADDRESS_TAG, fromAddress)
             .endObject()
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/SesAccountTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/SesAccountTests.kt
@@ -83,12 +83,47 @@ internal class SesAccountTests {
     }
 
     @Test
+    fun `SES serialize and deserialize using json object should be equal with null roleArn`() {
+        val sesAccount = SesAccount("us-east-1", null, "from@domain.com")
+        val jsonString = getJsonString(sesAccount)
+        val recreatedObject = createObjectFromJsonString(jsonString) { SesAccount.parse(it) }
+        assertEquals(sesAccount, recreatedObject)
+    }
+
+    @Test
     fun `SES should deserialize json object using parser`() {
         val sesAccount = SesAccount("us-east-1", "arn:aws:iam::012345678912:role/iam-test", "from@domain.com")
         val jsonString = """
         {
             "region":"${sesAccount.awsRegion}",
             "role_arn":"${sesAccount.roleArn}",
+            "from_address":"${sesAccount.fromAddress}"
+        }
+        """.trimIndent()
+        val recreatedObject = createObjectFromJsonString(jsonString) { SesAccount.parse(it) }
+        assertEquals(sesAccount, recreatedObject)
+    }
+
+    @Test
+    fun `SES should deserialize json object will null role_arn using parser`() {
+        val sesAccount = SesAccount("us-east-1", null, "from@domain.com")
+        val jsonString = """
+        {
+            "region":"${sesAccount.awsRegion}",
+            "role_arn":null,
+            "from_address":"${sesAccount.fromAddress}"
+        }
+        """.trimIndent()
+        val recreatedObject = createObjectFromJsonString(jsonString) { SesAccount.parse(it) }
+        assertEquals(sesAccount, recreatedObject)
+    }
+
+    @Test
+    fun `SES should deserialize json object will missing role_arn using parser`() {
+        val sesAccount = SesAccount("us-east-1", null, "from@domain.com")
+        val jsonString = """
+        {
+            "region":"${sesAccount.awsRegion}",
             "from_address":"${sesAccount.fromAddress}"
         }
         """.trimIndent()


### PR DESCRIPTION
### Description
BugFix: Allow null values for role_arn in json parsing

Signed-off-by: @akbhatta

### Issues Resolved
Allow null values for role_arn in json parsing
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
