### PR TITLE
Add Commits related to Snapshot build of Common Utils on 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,16 @@ jobs:
           ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
         
       # common-utils
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.1.0
+          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,17 @@ repositories {
     jcenter()
 }
 
-group 'org.opensearch.commons'
+ext {
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+}
+
+allprojects {
+    group 'org.opensearch.commons'
+    version = opensearch_version - '-SNAPSHOT' + '.0'
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
+}
 
 sourceCompatibility = 1.8
 
@@ -145,8 +155,6 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
-
-version '1.1.0.0'
 
 publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,8 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 
+version '1.1.0.0'
+
 publishing {
     publications {
         shadow(MavenPublication) {


### PR DESCRIPTION
### Description
This change adds commits related to snapshot build of Common Utils on 1.1
 
### Issues Resolved
#64
#65
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
