### PR TITLE
Correct hard-coded version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,8 +156,6 @@ task javadocJar(type: Jar) {
     from javadoc.destinationDir
 }
 
-version '1.1.0.0'
-
 publishing {
     publications {
         shadow(MavenPublication) {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

This fixes https://github.com/opensearch-project/opensearch-build/pull/430/checks?check_run_id=3569950574 by cherry-picking cc02f237de3ef45c3f7dc0bf526556d09bbaba97 from #58. The JAR version needs to be 1.1.0.0-SNAPSHOT when building a snapshot, and 1.1.0.0 otherwise, which is handled in property resolution.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
