### PR TITLE
Updates common-utils version to 1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.1'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: ./gradlew publishToMavenLocal
@@ -39,11 +39,11 @@ jobs:
       # common-utils
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
+          ./gradlew build -Dopensearch.version=1.2.0-SNAPSHOT
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
+          ./gradlew publishToMavenLocal -Dopensearch.version=1.2.0-SNAPSHOT
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # dependencies: OpenSearch
-      - name: Checkout OpenSearch
-        uses: actions/checkout@v2
-        with:
-          repository: 'opensearch-project/OpenSearch'
-          path: OpenSearch
-          ref: '1.x'
-      - name: Build OpenSearch
-        working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
-        
       # common-utils
       - name: Build and Test
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
         kotlin_version = System.getProperty("kotlin.version", "1.4.32")
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         jcenter()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     }
 
     dependencies {
@@ -42,6 +43,7 @@ repositories {
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     jcenter()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 
 ext {


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Updates common utils version to 1.2. Changes the gradle build file, as well as the github test and build workflow.
 
### Issues Resolved
opensearch-project/opensearch-build#663
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
