### PR TITLE
Update maven publication to include cksums.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,17 +157,13 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
-
-tasks.withType(Jar) { task ->
-    task.doLast {
-        ant.checksum algorithm: 'md5', file: it.archivePath
-        ant.checksum algorithm: 'sha1', file: it.archivePath
-        ant.checksum algorithm: 'sha-256', file: it.archivePath, fileext: '.sha256'
-        ant.checksum algorithm: 'sha-512', file: it.archivePath, fileext: '.sha512'
-    }
-}
-
 publishing {
+    repositories {
+        maven {
+            name = 'staging'
+            url = "${rootProject.buildDir}/local-staging-repo"
+        }
+    }
     publications {
         shadow(MavenPublication) {
             project.shadow.component(it)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -57,5 +57,6 @@ fi
 
 ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./build/libs $OUTPUT/maven/org/opensearch/common-utils
+cp -r ./build/local-staging-repo/org/opensearch/common-utils $OUTPUT/maven/org/opensearch/common-utils


### PR DESCRIPTION

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change adds a new task to publish to a local staging repo that includes checksums.  Also update build.sh to use this new task and copy the contents of the staging repo to the output directory.
The maven publish plugin will not include these cksums when publishing to maven local but will when published to a separate folder.

```
./scripts/build.sh -v 1.2.0-SNAPSHOT  
```
Result:
```
~/workspace/common-utils (maven)$ find artifacts/maven/org/opensearch/common-utils/
artifacts/maven/org/opensearch/common-utils/
artifacts/maven/org/opensearch/common-utils//maven-metadata.xml.sha256
artifacts/maven/org/opensearch/common-utils//maven-metadata.xml
artifacts/maven/org/opensearch/common-utils//maven-metadata.xml.sha512
artifacts/maven/org/opensearch/common-utils//1.2.0.0
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-javadoc.jar
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-javadoc.jar.sha1
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-sources.jar
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-sources.jar.sha512
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.jar
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.pom.sha256
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-javadoc.jar.md5
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.jar.sha512
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.pom
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.pom.sha1
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-javadoc.jar.sha256
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-sources.jar.md5
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.pom.md5
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-sources.jar.sha256
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-javadoc.jar.sha512
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.pom.sha512
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.jar.sha256
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0-sources.jar.sha1
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.jar.sha1
artifacts/maven/org/opensearch/common-utils//1.2.0.0/common-utils-1.2.0.0.jar.md5
artifacts/maven/org/opensearch/common-utils//maven-metadata.xml.md5
artifacts/maven/org/opensearch/common-utils//maven-metadata.xml.sha1
```

### Issues Resolved
closes #88 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
