### PR TITLE
Auto-increment version on new release tags.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       # common-utils
       - name: Build and Test
         run: |
-          ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
+          ./gradlew build
 
       - name: Publish to Maven Local
         run: |
-          ./gradlew publishToMavenLocal -Dopensearch.version=1.3.0-SNAPSHOT
+          ./gradlew publishToMavenLocal
           
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,42 @@
+name: Increment Version
+
+on:
+  push:
+    tags:
+      - '*.*.*.*'
+
+jobs:  
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch Tag and Version Information
+        run: |
+          TAG=$(echo "${GITHUB_REF#refs/*/}")
+          CURRENT_VERSION_ARRAY=($(echo "$TAG" | tr . '\n'))
+          BASE=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:2}")
+          CURRENT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          CURRENT_VERSION_ARRAY[2]=$((CURRENT_VERSION_ARRAY[2]+1))
+          NEXT_VERSION=$(IFS=. ; echo "${CURRENT_VERSION_ARRAY[*]:0:3}")
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "BASE=$BASE" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BASE }}
+      - name: Increment Version
+        run: |
+          echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
+          sed -i "s/$CURRENT_VERSION-SNAPSHOT/$NEXT_VERSION-SNAPSHOT/g" build.gradle
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: ${{ env.BASE }}
+          commit-message: Incremented version to ${{ env.NEXT_VERSION }}
+          delete-branch: true
+          title: '[AUTO] Incremented version to ${{ env.NEXT_VERSION }}.'
+          body: |
+            I've noticed that a new tag ${{ env.TAG }} was pushed, and incremented the version from ${{ env.CURRENT_VERSION }} to ${{ env.NEXT_VERSION }}.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds a workflow that increments the version in `build.gradle` whenever a new X.Y.Z.0 tag is pushed. 

- Successful run: https://github.com/dblock/common-utils/actions/runs/1631200088
- PR: https://github.com/dblock/common-utils/pull/1

The idea is that every repo can have its own version of this to increment a patch release. When, for example, 1.2.3 is released and tagged, every repo would automatically get a PR to increment the version to the next development iteration on the release branch (e.g. 1.2). These jobs would fail until a -SNAPSHOT build of OpenSearch is available, which is already automated. One would come to this PR, re-run the CI, and merge on green.

### Notes

The version is removed from ci.yml because the workflow is not allowed to push a change to workflows without a different access token. You get this error.

```
To https://github.com/dblock/common-utils
   ! [remote rejected] HEAD -> create-pull-request/patch (refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission)
  error: failed to push some refs to 'https://github.com/dblock/common-utils'
```

We can just use the default in build.gradle.
 
### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/1375.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
