### PR TITLE
Using Github App token to trigger CI for version increment PRs

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -8,9 +8,15 @@ on:
 jobs:  
   build:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - uses: actions/checkout@v2
       - name: Fetch Tag and Version Information
         run: |
@@ -27,13 +33,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.BASE }}
+          token: ${{ steps.github_app_token.outputs.token }}
+
       - name: Increment Version
         run: |
           echo Incrementing $CURRENT_VERSION to $NEXT_VERSION
           sed -i "s/$CURRENT_VERSION-SNAPSHOT/$NEXT_VERSION-SNAPSHOT/g" build.gradle
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ steps.github_app_token.outputs.token }}
           base: ${{ env.BASE }}
           commit-message: Incremented version to ${{ env.NEXT_VERSION }}
           delete-branch: true


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Using Github App token to trigger CI on PRs created for version increment from the version.yml workflow. (https://github.com/opensearch-project/common-utils/pull/111#issuecomment-1039635451)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
