### PR TITLE
Remove jcenter repository missed on first pass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    jcenter()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 


### PR DESCRIPTION
### Description
Remove jcenter repository change that was missing during #115, see https://github.com/opensearch-project/opensearch-build/issues/1456 for additional context

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
