### PR TITLE
Run CI/CD on Java 8, 11, 14 and 17.

### DIFF
--- a/.github/workflows/ci-17.yml
+++ b/.github/workflows/ci-17.yml
@@ -1,0 +1,40 @@
+name: Build and Test
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+
+    name: Build and Test (17)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Java 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Build 
+        run: |
+          ./gradlew build --build-cache
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Test 
+        run: |
+          ./gradlew test --build-cache
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [14]
+        java: 
+          - 8
+          - 11
+          - 14
 
     name: Build and Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
 
-      # common-utils
       - name: Build and Test
         run: |
           ./gradlew build

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,7 +1,7 @@
 - [Developer Guide](#developer-guide)
   - [Forking and Cloning](#forking-and-cloning)
   - [Install Prerequisites](#install-prerequisites)
-    - [JDK 14](#jdk-14)
+    - [JDK 11](#jdk-11)
   - [Building](#building)
   - [Using IntelliJ IDEA](#using-intellij-idea)
   - [Submitting Changes](#submitting-changes)
@@ -16,9 +16,9 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 ### Install Prerequisites
 
-#### JDK 14
+#### JDK 11
 
-OpenSearch components build using Java 14 at a minimum. This means you must have a JDK 14 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 14 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-14`.
+OpenSearch components build using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
 
 ### Building
 

--- a/src/test/java/org/opensearch/commons/InjectSecurityTest.java
+++ b/src/test/java/org/opensearch/commons/InjectSecurityTest.java
@@ -15,7 +15,7 @@ import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_INJECTE
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USE_INJECTED_USER_FOR_PLUGINS;
 
 import java.util.Arrays;
-import java.util.Map;
+import java.util.HashMap;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.settings.Settings;
@@ -114,7 +114,11 @@ public class InjectSecurityTest {
             assertTrue(helper.injectProperty("property1", true));
             assertTrue(helper.injectProperty("property2", "some value"));
             assertTrue(helper.injectProperty("property3", ""));
-            assertTrue(helper.injectProperty("property4", Map.of("key", "value")));
+            assertTrue(helper.injectProperty("property4", new HashMap<String, String>() {
+                {
+                    put("key", "value");
+                }
+            }));
             // verify the set properties are not null and equal to what was set
             assertNull(threadContext.getTransient("property"));
             assertNotNull(threadContext.getTransient("property1"));
@@ -124,7 +128,11 @@ public class InjectSecurityTest {
             assertNotNull(threadContext.getTransient("property3"));
             assertEquals("", threadContext.getTransient("property3"));
             assertNotNull(threadContext.getTransient("property4"));
-            assertEquals(Map.of("key", "value"), threadContext.getTransient("property4"));
+            assertEquals(new HashMap<String, String>() {
+                {
+                    put("key", "value");
+                }
+            }, threadContext.getTransient("property4"));
         }
         assertEquals("1", threadContext.getHeader("default"));
         assertEquals("opendistro", threadContext.getHeader("name"));


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

- Uses the standard CI matrix to build and test on JDK 8, 11, and 14.
- Since Gradle 6 doesn't support JDK 17, build on 11, and test on 17. Not sure whether there's a better way to do this?

```
Run ./gradlew build --build-cache
  ./gradlew build --build-cache
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.14-101/x64
```

```
Run ./gradlew test --build-cache
  ./gradlew test --build-cache
  shell: /usr/bin/bash -e {0}
  env:
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.2-8/x64
```
 
When we upgrade to Gradle 7 we can ran the 11, 14, 17 matrix and remove `ci.17.yml`.

### Issues Resolved

Closes #100.
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
