### PR TITLE
Backport to 1.3 : Add release notes for version 1.3.0.0

### DIFF
--- a/release-notes/opensearch-common-utils.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-common-utils.release-notes-1.3.0.0.md
@@ -1,0 +1,14 @@
+## Version 1.3.0.0 2022-03-11
+
+Compatible with OpenSearch 1.3.0
+
+### Infrastructure
+
+  * Updates common-utils version to 1.3 ([#99](https://github.com/opensearch-project/common-utils/pull/99))
+  * Update build.sh script to include optional platform param. ([#95](https://github.com/opensearch-project/common-utils/pull/95))
+  * Update copyright notice and add DCO check workflow. ([#94](https://github.com/opensearch-project/common-utils/pull/94))
+
+### Documentation
+
+  * Update copyright headers ([#117](https://github.com/opensearch-project/common-utils/pull/117))
+  * Add release notes for version 1.3.0.0 ([#132](https://github.com/opensearch-project/common-utils/pull/132))


### PR DESCRIPTION
### Description
Backport to 1.3 : Add release notes for version 1.3.0.0
 
### Issues Resolved
Backport https://github.com/opensearch-project/common-utils/pull/132
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
