### PR TITLE
Remove feature and feature_list usage for Notifications

### DIFF
--- a/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
@@ -6,7 +6,7 @@
 package org.opensearch.commons.destination.message;
 
 /**
- * Supported legacy notification destinations for Index Management
+ * Supported legacy notification destinations for Alerting and Index Management
  */
 public enum LegacyDestinationType {
     LEGACY_CHIME,

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
@@ -69,9 +69,5 @@ object NotificationConstants {
     const val ALLOWED_CONFIG_FEATURE_LIST_TAG = "allowed_config_feature_list"
     const val PLUGIN_FEATURES_TAG = "plugin_features"
 
-    const val FEATURE_ALERTING = "alerting"
-    const val FEATURE_INDEX_MANAGEMENT = "index_management"
-    const val FEATURE_REPORTS = "reports"
-
     const val DEFAULT_MAX_ITEMS = 1000
 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
@@ -36,7 +36,6 @@ object NotificationConstants {
     const val NAME_TAG = "name"
     const val DESCRIPTION_TAG = "description"
     const val IS_ENABLED_TAG = "is_enabled"
-    const val FEATURE_LIST_TAG = "feature_list"
     const val TITLE_TAG = "title"
     const val SEVERITY_TAG = "severity"
     const val TAGS_TAG = "tags"

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -200,7 +200,7 @@ object NotificationsPluginInterface {
 
     /**
      * Publishes a notification API using the legacy notification implementation. No REST API.
-     * Internal API only for the Index Management plugin.
+     * Internal API only for the Alerting and Index Management plugin, other consumers should use [sendNotification].
      * @param client Node client for making transport action
      * @param request The legacy publish notification request
      * @param listener The listener for getting response

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -9,7 +9,6 @@ import org.opensearch.action.ActionResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
 import org.opensearch.commons.notifications.action.BaseResponse
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
@@ -211,11 +210,6 @@ object NotificationsPluginInterface {
         request: LegacyPublishNotificationRequest,
         listener: ActionListener<LegacyPublishNotificationResponse>
     ) {
-        if (request.feature != FEATURE_INDEX_MANAGEMENT) {
-            // Do not change this; do not pass in FEATURE_INDEX_MANAGEMENT if you are not the Index Management plugin.
-            throw IllegalArgumentException("The publish notification method only supports the Index Management feature.")
-        }
-
         client.execute(
             LEGACY_PUBLISH_NOTIFICATION_ACTION_TYPE,
             request,

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
@@ -23,7 +23,6 @@ import java.io.IOException
  */
 class LegacyPublishNotificationRequest : ActionRequest {
     val baseMessage: LegacyBaseMessage
-    val feature: String
 
     companion object {
         /**
@@ -35,14 +34,11 @@ class LegacyPublishNotificationRequest : ActionRequest {
     /**
      * constructor for creating the class
      * @param baseMessage the base message to send
-     * @param feature the feature that is trying to use this request
      */
     constructor(
-        baseMessage: LegacyBaseMessage,
-        feature: String
+        baseMessage: LegacyBaseMessage
     ) {
         this.baseMessage = baseMessage
-        this.feature = feature
     }
 
     /**
@@ -55,7 +51,6 @@ class LegacyPublishNotificationRequest : ActionRequest {
             LegacyDestinationType.LEGACY_CUSTOM_WEBHOOK -> LegacyCustomWebhookMessage(input)
             LegacyDestinationType.LEGACY_SLACK -> LegacySlackMessage(input)
         }
-        feature = input.readString()
     }
 
     /**
@@ -66,7 +61,6 @@ class LegacyPublishNotificationRequest : ActionRequest {
         super.writeTo(output)
         output.writeEnum(baseMessage.channelType)
         baseMessage.writeTo(output)
-        output.writeString(feature)
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
@@ -52,7 +52,7 @@ object NotificationsActions {
 
     /**
      * Publish legacy notification message. Internal only - Inter plugin communication.
-     * Only for the Index Management plugin.
+     * Only for the Alerting and Index Management plugins.
      */
     const val LEGACY_PUBLISH_NOTIFICATION_NAME = "cluster:admin/opensearch/notifications/feature/publish"
 
@@ -106,7 +106,7 @@ object NotificationsActions {
 
     /**
      * Send legacy notification transport action type. Internal only - Inter plugin communication.
-     * Only for the Index Management plugin.
+     * Only for the Alerting and Index Management plugins.
      */
     val LEGACY_PUBLISH_NOTIFICATION_ACTION_TYPE =
         ActionType(LEGACY_PUBLISH_NOTIFICATION_NAME, ::LegacyPublishNotificationResponse)

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/EventSource.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/EventSource.kt
@@ -12,7 +12,6 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_TAG
 import org.opensearch.commons.notifications.NotificationConstants.REFERENCE_ID_TAG
 import org.opensearch.commons.notifications.NotificationConstants.SEVERITY_TAG
 import org.opensearch.commons.notifications.NotificationConstants.TAGS_TAG
@@ -27,7 +26,6 @@ import java.io.IOException
 data class EventSource(
     val title: String,
     val referenceId: String,
-    val feature: String,
     val severity: SeverityType = SeverityType.INFO,
     val tags: List<String> = listOf()
 ) : BaseModel {
@@ -53,7 +51,6 @@ data class EventSource(
         fun parse(parser: XContentParser): EventSource {
             var title: String? = null
             var referenceId: String? = null
-            var feature: String? = null
             var severity: SeverityType = SeverityType.INFO
             var tags: List<String> = emptyList()
 
@@ -68,7 +65,6 @@ data class EventSource(
                 when (fieldName) {
                     TITLE_TAG -> title = parser.text()
                     REFERENCE_ID_TAG -> referenceId = parser.text()
-                    FEATURE_TAG -> feature = parser.text()
                     SEVERITY_TAG -> severity = SeverityType.fromTagOrDefault(parser.text())
                     TAGS_TAG -> tags = parser.stringList()
                     else -> {
@@ -79,12 +75,10 @@ data class EventSource(
             }
             title ?: throw IllegalArgumentException("$TITLE_TAG field absent")
             referenceId ?: throw IllegalArgumentException("$REFERENCE_ID_TAG field absent")
-            feature ?: throw IllegalArgumentException("$FEATURE_TAG field absent")
 
             return EventSource(
                 title,
                 referenceId,
-                feature,
                 severity,
                 tags
             )
@@ -99,7 +93,6 @@ data class EventSource(
         return builder.startObject()
             .field(TITLE_TAG, title)
             .field(REFERENCE_ID_TAG, referenceId)
-            .field(FEATURE_TAG, feature)
             .field(SEVERITY_TAG, severity.tag)
             .field(TAGS_TAG, tags)
             .endObject()
@@ -112,7 +105,6 @@ data class EventSource(
     constructor(input: StreamInput) : this(
         title = input.readString(),
         referenceId = input.readString(),
-        feature = input.readString(),
         severity = input.readEnum(SeverityType::class.java),
         tags = input.readStringList()
     )
@@ -123,7 +115,6 @@ data class EventSource(
     override fun writeTo(output: StreamOutput) {
         output.writeString(title)
         output.writeString(referenceId)
-        output.writeString(feature)
         output.writeEnum(severity)
         output.writeStringCollection(tags)
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -21,7 +21,6 @@ import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.destination.response.LegacyDestinationResponse
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
@@ -231,10 +230,6 @@ internal class NotificationsPluginInterfaceTests {
             (it.getArgument(2) as ActionListener<LegacyPublishNotificationResponse>)
                 .onResponse(res)
         }.whenever(client).execute(any(ActionType::class.java), any(), any())
-
-        doAnswer {
-            FEATURE_INDEX_MANAGEMENT
-        }.whenever(request).feature
 
         NotificationsPluginInterface.publishLegacyNotification(client, request, l)
         verify(l, times(1)).onResponse(eq(res))

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -21,9 +21,7 @@ import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
 import org.opensearch.commons.destination.response.LegacyDestinationResponse
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
 import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
@@ -198,7 +196,6 @@ internal class NotificationsPluginInterfaceTests {
         val notificationInfo = EventSource(
             "title",
             "reference_id",
-            FEATURE_REPORTS,
             SeverityType.HIGH,
             listOf("tag1", "tag2")
         )
@@ -264,7 +261,6 @@ internal class NotificationsPluginInterfaceTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -249,7 +249,6 @@ internal class NotificationsPluginInterfaceTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
 import org.opensearch.commons.notifications.model.Chime
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.Email
@@ -32,9 +31,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleWebhook
+            configData = sampleWebhook,
+            isEnabled = true
         )
     }
 
@@ -44,9 +42,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
     }
 
@@ -56,9 +53,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleChime
+            configData = sampleChime,
+            isEnabled = true
         )
     }
 
@@ -68,9 +64,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmailGroup
+            configData = sampleEmailGroup,
+            isEnabled = true
         )
     }
 
@@ -84,9 +79,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmail
+            configData = sampleEmail,
+            isEnabled = true
         )
     }
 
@@ -101,9 +95,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSmtpAccount
+            configData = sampleSmtpAccount,
+            isEnabled = true
         )
     }
 
@@ -264,9 +257,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -292,9 +284,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleWebhook
+            configData = sampleWebhook,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -320,9 +311,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleChime
+            configData = sampleChime,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -349,9 +339,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmailGroup
+            configData = sampleEmailGroup,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -382,9 +371,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmail
+            configData = sampleEmail,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -420,9 +408,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSmtpAccount
+            configData = sampleSmtpAccount,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -488,9 +475,8 @@ internal class CreateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
 
         val jsonString = """

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
@@ -267,7 +267,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"slack",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "slack":{"url":"https://domain.com/sample_slack_url#1234567890"}
             }
@@ -294,7 +293,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"webhook",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "webhook":{"url":"https://domain.com/sample_webhook_url#1234567890"}
             }
@@ -322,7 +320,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"chime",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "chime":{"url":"https://domain.com/sample_chime_url#1234567890"}
             }
@@ -350,7 +347,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"email_group",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "email_group":{"recipient_list":[{"recipient":"dummy@company.com"}]}
             }
@@ -382,7 +378,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"email",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "email":{
                     "email_account_id":"sample_1@dummy.com",
@@ -419,7 +414,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"smtp_account",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "smtp_account":{"host":"http://dummy.com", "port":11,"method": "ssl", "from_address": "sample@dummy.com" }
             }
@@ -450,7 +444,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"chime",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "chime":{"url":"https://domain.com/sample_chime_url#1234567890"}
             }
@@ -485,7 +478,6 @@ internal class CreateNotificationConfigRequestTests {
                 "name":"name",
                 "description":"description",
                 "config_type":"slack",
-                "feature_list":["index_management"],
                 "is_enabled":true,
                 "slack":{"url":"https://domain.com/sample_slack_url#1234567890"},
                 "extra_field_1":["extra", "value"],

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetFeatureChannelListRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetFeatureChannelListRequestTests.kt
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.core.JsonParseException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -21,19 +18,19 @@ internal class GetFeatureChannelListRequestTests {
         expected: GetFeatureChannelListRequest,
         actual: GetFeatureChannelListRequest
     ) {
-        assertEquals(expected.feature, actual.feature)
+        assertEquals(expected.compact, actual.compact)
     }
 
     @Test
     fun `Get request serialize and deserialize transport object should be equal`() {
-        val configRequest = GetFeatureChannelListRequest(FEATURE_REPORTS)
+        val configRequest = GetFeatureChannelListRequest()
         val recreatedObject = recreateObject(configRequest) { GetFeatureChannelListRequest(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
     }
 
     @Test
     fun `Get request serialize and deserialize using json object should be equal`() {
-        val configRequest = GetFeatureChannelListRequest(FEATURE_INDEX_MANAGEMENT)
+        val configRequest = GetFeatureChannelListRequest()
         val jsonString = getJsonString(configRequest)
         val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
@@ -49,10 +46,9 @@ internal class GetFeatureChannelListRequestTests {
 
     @Test
     fun `Get request should safely ignore extra field in json object`() {
-        val configRequest = GetFeatureChannelListRequest(FEATURE_ALERTING)
+        val configRequest = GetFeatureChannelListRequest()
         val jsonString = """
         {
-            "feature":"${configRequest.feature}",
             "extra_field_1":["extra", "value"],
             "extra_field_2":{"extra":"value"},
             "extra_field_3":"extra value 3"
@@ -60,16 +56,5 @@ internal class GetFeatureChannelListRequestTests {
         """.trimIndent()
         val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
-    }
-
-    @Test
-    fun `Get request should throw exception if feature field is absent in json object`() {
-        val jsonString = """
-        {
-        }
-        """.trimIndent()
-        assertThrows<IllegalArgumentException> {
-            createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
-        }
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationConfigResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationConfigResponseTests.kt
@@ -187,7 +187,6 @@ internal class GetNotificationConfigResponseTests {
                         "name":"name",
                         "description":"description",
                         "config_type":"slack",
-                        "feature_list":["index_management"],
                         "is_enabled":true,
                         "slack":{"url":"https://domain.com/sample_slack_url#1234567890"}
                     }
@@ -232,7 +231,6 @@ internal class GetNotificationConfigResponseTests {
                         "name":"name",
                         "description":"description",
                         "config_type":"slack",
-                        "feature_list":["index_management"],
                         "is_enabled":true,
                         "slack":{"url":"https://domain.com/sample_slack_url#1234567890"}
                     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationConfigResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationConfigResponseTests.kt
@@ -8,8 +8,6 @@ import org.apache.lucene.search.TotalHits
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.Chime
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.NotificationConfig
@@ -41,7 +39,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -62,7 +59,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = Slack("https://domain.com/sample_url#1234567890")
         )
         val configInfo1 = NotificationConfigInfo(
@@ -75,7 +71,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = Chime("https://domain.com/sample_url#1234567890")
         )
         val configInfo2 = NotificationConfigInfo(
@@ -104,7 +99,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -128,7 +122,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = Slack("https://domain.com/sample_url#1234567890")
         )
         val configInfo1 = NotificationConfigInfo(
@@ -141,7 +134,6 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = Chime("https://domain.com/sample_url#1234567890")
         )
         val configInfo2 = NotificationConfigInfo(
@@ -171,9 +163,8 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val configInfo = NotificationConfigInfo(
             "config-Id",
@@ -220,9 +211,8 @@ internal class GetNotificationConfigResponseTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val configInfo = NotificationConfigInfo(
             "config-Id",

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationEventResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetNotificationEventResponseTests.kt
@@ -8,8 +8,6 @@ import org.apache.lucene.search.TotalHits
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.DeliveryStatus
 import org.opensearch.commons.notifications.model.EventSource
@@ -41,7 +39,6 @@ internal class GetNotificationEventResponseTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -68,13 +65,11 @@ internal class GetNotificationEventResponseTests {
         val eventSource1 = EventSource(
             "title 1",
             "reference_id_1",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val eventSource2 = EventSource(
             "title 2",
             "reference_id_2",
-            FEATURE_REPORTS,
             severity = SeverityType.HIGH
         )
         val status1 = EventStatus(
@@ -131,7 +126,6 @@ internal class GetNotificationEventResponseTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -161,13 +155,11 @@ internal class GetNotificationEventResponseTests {
         val eventSource1 = EventSource(
             "title 1",
             "reference_id_1",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val eventSource2 = EventSource(
             "title 2",
             "reference_id_2",
-            FEATURE_REPORTS,
             severity = SeverityType.HIGH
         )
         val status1 = EventStatus(
@@ -213,7 +205,6 @@ internal class GetNotificationEventResponseTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -244,7 +235,6 @@ internal class GetNotificationEventResponseTests {
                         "event_source":{
                             "title":"title",
                             "reference_id":"reference_id",
-                            "feature":"alerting",
                             "severity":"info",
                             "tags":[]
                         },
@@ -279,7 +269,6 @@ internal class GetNotificationEventResponseTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -307,7 +296,6 @@ internal class GetNotificationEventResponseTests {
                         "event_source":{
                             "title":"title",
                             "reference_id":"reference_id",
-                            "feature":"alerting",
                             "severity":"info",
                             "tags":[]
                         },

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequestTests.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.opensearch.commons.destination.message.LegacyChimeMessage
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
 import org.opensearch.commons.utils.recreateObject
 
 internal class LegacyPublishNotificationRequestTests {
@@ -22,14 +21,13 @@ internal class LegacyPublishNotificationRequestTests {
         assertEquals(expected.baseMessage.channelType, actual.baseMessage.channelType)
         assertEquals(expected.baseMessage.messageContent, actual.baseMessage.messageContent)
         assertEquals(expected.baseMessage.url, actual.baseMessage.url)
-        assertEquals(expected.feature, actual.feature)
         assertNull(actual.validate())
     }
 
     @Test
     fun `publish request serialize and deserialize transport object should be equal`() {
         val baseMessage = LegacyChimeMessage.Builder("chime_message").withMessage("Hello world").withUrl("https://amazon.com").build()
-        val request = LegacyPublishNotificationRequest(baseMessage, FEATURE_INDEX_MANAGEMENT)
+        val request = LegacyPublishNotificationRequest(baseMessage)
         val recreatedObject = recreateObject(request) { LegacyPublishNotificationRequest(it) }
         assertRequestEquals(request, recreatedObject)
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationRequestTests.kt
@@ -10,9 +10,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.notifications.model.ChannelMessage
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.SeverityType
@@ -38,7 +35,6 @@ internal class SendNotificationRequestTests {
         val notificationInfo = EventSource(
             "title",
             "reference_id",
-            FEATURE_REPORTS,
             SeverityType.HIGH,
             listOf("tag1", "tag2")
         )
@@ -62,7 +58,6 @@ internal class SendNotificationRequestTests {
         val notificationInfo = EventSource(
             "title",
             "reference_id",
-            FEATURE_INDEX_MANAGEMENT,
             SeverityType.CRITICAL,
             listOf("tag1", "tag2")
         )
@@ -95,7 +90,6 @@ internal class SendNotificationRequestTests {
         val notificationInfo = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             SeverityType.HIGH,
             listOf("tag1", "tag2")
         )
@@ -115,7 +109,6 @@ internal class SendNotificationRequestTests {
             "event_source":{
                 "title":"${notificationInfo.title}",
                 "reference_id":"${notificationInfo.referenceId}",
-                "feature":"${notificationInfo.feature}",
                 "severity":"${notificationInfo.severity}",
                 "tags":["tag1", "tag2"]
             },
@@ -139,7 +132,6 @@ internal class SendNotificationRequestTests {
         val notificationInfo = EventSource(
             "title",
             "reference_id",
-            FEATURE_REPORTS,
             SeverityType.INFO,
             listOf("tag1", "tag2")
         )
@@ -159,7 +151,6 @@ internal class SendNotificationRequestTests {
             "event_source":{
                 "title":"${notificationInfo.title}",
                 "reference_id":"${notificationInfo.referenceId}",
-                "feature":"${notificationInfo.feature}",
                 "severity":"${notificationInfo.severity}",
                 "tags":["tag1", "tag2"]
             },
@@ -196,7 +187,6 @@ internal class SendNotificationRequestTests {
             "event_source":{
                 "title":"title",
                 "reference_id":"reference_id",
-                "feature":"feature",
                 "severity":"High",
                 "tags":["tag1", "tag2"]
             },
@@ -215,7 +205,6 @@ internal class SendNotificationRequestTests {
             "event_source":{
                 "title":"title",
                 "reference_id":"reference_id",
-                "feature":"feature",
                 "severity":"High",
                 "tags":["tag1", "tag2"]
             },
@@ -236,7 +225,6 @@ internal class SendNotificationRequestTests {
             "event_source":{
                 "title":"title",
                 "reference_id":"reference_id",
-                "feature":"feature",
                 "severity":"High",
                 "tags":["tag1", "tag2"]
             },

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/UpdateNotificationConfigRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/UpdateNotificationConfigRequestTests.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
 import org.opensearch.commons.notifications.model.Chime
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.Email
@@ -32,9 +31,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleWebhook
+            configData = sampleWebhook,
+            isEnabled = true
         )
     }
 
@@ -44,9 +42,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
     }
 
@@ -56,9 +53,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleChime
+            configData = sampleChime,
+            isEnabled = true
         )
     }
 
@@ -68,9 +64,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmailGroup
+            configData = sampleEmailGroup,
+            isEnabled = true
         )
     }
 
@@ -84,9 +79,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmail
+            configData = sampleEmail,
+            isEnabled = true
         )
     }
 
@@ -101,9 +95,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSmtpAccount
+            configData = sampleSmtpAccount,
+            isEnabled = true
         )
     }
 
@@ -228,9 +221,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -258,9 +250,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleWebhook
+            configData = sampleWebhook,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -288,9 +279,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleChime
+            configData = sampleChime,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -318,9 +308,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmailGroup
+            configData = sampleEmailGroup,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -352,9 +341,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleEmail
+            configData = sampleEmail,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -391,9 +379,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSmtpAccount
+            configData = sampleSmtpAccount,
+            isEnabled = true
         )
 
         val jsonString = """
@@ -429,9 +416,8 @@ internal class UpdateNotificationConfigRequestTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
 
         val jsonString = """

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/EventSourceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/EventSourceTests.kt
@@ -7,7 +7,6 @@ package org.opensearch.commons.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -19,7 +18,6 @@ internal class EventSourceTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val recreatedObject = recreateObject(sampleEventSource) { EventSource(it) }
@@ -31,7 +29,6 @@ internal class EventSourceTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
 
@@ -45,9 +42,8 @@ internal class EventSourceTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
-            tags = listOf("tag1", "tag2"),
-            severity = SeverityType.INFO
+            severity = SeverityType.INFO,
+            tags = listOf("tag1", "tag2")
         )
         val jsonString = """
         { 
@@ -70,9 +66,8 @@ internal class EventSourceTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            "NewFeature",
-            tags = listOf("tag1", "tag2"),
-            severity = SeverityType.INFO
+            severity = SeverityType.INFO,
+            tags = listOf("tag1", "tag2")
         )
         val jsonString = """
         {
@@ -93,9 +88,8 @@ internal class EventSourceTests {
             EventSource(
                 "",
                 "reference_id",
-                FEATURE_ALERTING,
-                tags = listOf("tag1", "tag2"),
-                severity = SeverityType.INFO
+                severity = SeverityType.INFO,
+                tags = listOf("tag1", "tag2")
             )
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigInfoTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigInfoTests.kt
@@ -7,8 +7,6 @@ package org.opensearch.commons.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -23,7 +21,6 @@ internal class NotificationConfigInfoTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -45,7 +42,6 @@ internal class NotificationConfigInfoTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -68,9 +64,8 @@ internal class NotificationConfigInfoTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val configInfo = NotificationConfigInfo(
             "config-Id",
@@ -107,7 +102,6 @@ internal class NotificationConfigInfoTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         Assertions.assertThrows(IllegalArgumentException::class.java) {

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigSearchResultsTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigSearchResultsTests.kt
@@ -8,8 +8,6 @@ import org.apache.lucene.search.TotalHits
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -35,7 +33,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -55,7 +52,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = Slack("https://domain.com/sample_url#1234567890")
         )
         val configInfo1 = NotificationConfigInfo(
@@ -68,7 +64,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = Chime("https://domain.com/sample_url#1234567890")
         )
         val configInfo2 = NotificationConfigInfo(
@@ -94,7 +89,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = Slack("https://domain.com/sample_url#1234567890")
         )
         val configInfo1 = NotificationConfigInfo(
@@ -107,7 +101,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = Chime("https://domain.com/sample_url#1234567890")
         )
         val configInfo2 = NotificationConfigInfo(
@@ -135,7 +128,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val configInfo = NotificationConfigInfo(
@@ -158,7 +150,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = Slack("https://domain.com/sample_url#1234567890")
         )
         val configInfo1 = NotificationConfigInfo(
@@ -171,7 +162,6 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = Chime("https://domain.com/sample_url#1234567890")
         )
         val configInfo2 = NotificationConfigInfo(
@@ -200,9 +190,8 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val configInfo = NotificationConfigInfo(
             "config-Id",
@@ -249,9 +238,8 @@ internal class NotificationConfigSearchResultsTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val configInfo = NotificationConfigInfo(
             "config-Id",

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigTests.kt
@@ -6,9 +6,6 @@ package org.opensearch.commons.notifications.model
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_INDEX_MANAGEMENT
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -22,7 +19,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -36,7 +32,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.SLACK,
-            setOf(FEATURE_REPORTS),
             configData = sampleSlack
         )
         val jsonString = getJsonString(sampleConfig)
@@ -51,7 +46,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING),
             configData = sampleChime
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -65,7 +59,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.CHIME,
-            setOf(FEATURE_ALERTING),
             configData = sampleChime
         )
         val jsonString = getJsonString(sampleConfig)
@@ -80,7 +73,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleWebhook
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -94,7 +86,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleWebhook
         )
         val jsonString = getJsonString(sampleConfig)
@@ -109,7 +100,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleEmail
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -123,7 +113,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.EMAIL,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleEmail
         )
         val jsonString = getJsonString(sampleConfig)
@@ -138,7 +127,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = smtpAccount
         )
         val jsonString = getJsonString(sampleConfig)
@@ -153,7 +141,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.SMTP_ACCOUNT,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleSmtpAccount
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -167,7 +154,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleEmailGroup
         )
         val jsonString = getJsonString(sampleConfig)
@@ -182,7 +168,6 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.EMAIL_GROUP,
-            setOf(FEATURE_INDEX_MANAGEMENT),
             configData = sampleEmailGroup
         )
         val recreatedObject = recreateObject(sampleConfig) { NotificationConfig(it) }
@@ -197,9 +182,8 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.NONE,
-            setOf(FEATURE_INDEX_MANAGEMENT),
-            isEnabled = true,
-            configData = sampleSlack
+            configData = sampleSlack,
+            isEnabled = true
         )
         val jsonString = """
         {
@@ -226,9 +210,8 @@ internal class NotificationConfigTests {
             "name",
             "description",
             ConfigType.WEBHOOK,
-            setOf(FEATURE_INDEX_MANAGEMENT, "NewFeature1", "NewFeature2"),
-            isEnabled = true,
-            configData = sampleWebhook
+            configData = sampleWebhook,
+            isEnabled = true
         )
         val jsonString = """
         {

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventInfoTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventInfoTests.kt
@@ -7,7 +7,6 @@ package org.opensearch.commons.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -20,7 +19,6 @@ internal class NotificationEventInfoTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -47,7 +45,6 @@ internal class NotificationEventInfoTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -75,7 +72,6 @@ internal class NotificationEventInfoTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -133,7 +129,6 @@ internal class NotificationEventInfoTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventSearchResultTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventSearchResultTests.kt
@@ -8,8 +8,6 @@ import org.apache.lucene.search.TotalHits
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -33,7 +31,6 @@ internal class NotificationEventSearchResultTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -59,13 +56,11 @@ internal class NotificationEventSearchResultTests {
         val eventSource1 = EventSource(
             "title 1",
             "reference_id_1",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val eventSource2 = EventSource(
             "title 2",
             "reference_id_2",
-            FEATURE_REPORTS,
             severity = SeverityType.HIGH
         )
         val status1 = EventStatus(
@@ -122,13 +117,11 @@ internal class NotificationEventSearchResultTests {
         val eventSource1 = EventSource(
             "title 1",
             "reference_id_1",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val eventSource2 = EventSource(
             "title 2",
             "reference_id_2",
-            FEATURE_REPORTS,
             severity = SeverityType.HIGH
         )
         val status1 = EventStatus(
@@ -184,7 +177,6 @@ internal class NotificationEventSearchResultTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -213,13 +205,11 @@ internal class NotificationEventSearchResultTests {
         val eventSource1 = EventSource(
             "title 1",
             "reference_id_1",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val eventSource2 = EventSource(
             "title 2",
             "reference_id_2",
-            FEATURE_REPORTS,
             severity = SeverityType.HIGH
         )
         val status1 = EventStatus(
@@ -264,7 +254,6 @@ internal class NotificationEventSearchResultTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -330,7 +319,6 @@ internal class NotificationEventSearchResultTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationEventTests.kt
@@ -7,8 +7,6 @@ package org.opensearch.commons.notifications.model
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_ALERTING
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_REPORTS
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
@@ -20,7 +18,6 @@ internal class NotificationEventTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -39,7 +36,6 @@ internal class NotificationEventTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_REPORTS,
             severity = SeverityType.INFO
         )
         val sampleStatus = EventStatus(
@@ -59,9 +55,8 @@ internal class NotificationEventTests {
         val sampleEventSource = EventSource(
             "title",
             "reference_id",
-            FEATURE_ALERTING,
-            tags = listOf("tag1", "tag2"),
-            severity = SeverityType.INFO
+            severity = SeverityType.INFO,
+            tags = listOf("tag1", "tag2")
         )
         val status1 = EventStatus(
             "config_id1",


### PR DESCRIPTION
### Description
* Removes feature usage from NotificationConfig
* Removes feature usage from FeatureChannelList request
* Removes feature usage from EventSource
* Removes feature from LegacyPublishNotification

There will also be a complementary PR made in the Notifications project to integrate these changes.

There are still some indirect references to features like the enabled features returned in the GetPluginFeatures API which will be addressed in a follow-up PR.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
