### PR TITLE
Add opensearch repositories plugin to resolve lucene snapshot dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
+apply plugin: 'opensearch.repositories'
 
 configurations {
     ktlint


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Updates common-utils to depend on the OpenSearch repositories plugin.  This allows common-utils to fetch snapshot lucene dependencies.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2500
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
