### PR TITLE
Rename references for Get Channels API for Notifications

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
@@ -52,7 +52,7 @@ object NotificationConstants {
     const val CREATED_TIME_TAG = "created_time_ms"
     const val CONFIG_LIST_TAG = "config_list"
     const val EVENT_LIST_TAG = "event_list"
-    const val FEATURE_CONFIG_LIST_TAG = "feature_channel_list"
+    const val CHANNEL_LIST_TAG = "channel_list"
     const val DELETE_RESPONSE_LIST_TAG = "delete_response_list"
     const val FROM_INDEX_TAG = "from_index"
     const val MAX_ITEMS_TAG = "max_items"

--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterface.kt
@@ -14,8 +14,8 @@ import org.opensearch.commons.notifications.action.CreateNotificationConfigReque
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigResponse
-import org.opensearch.commons.notifications.action.GetFeatureChannelListRequest
-import org.opensearch.commons.notifications.action.GetFeatureChannelListResponse
+import org.opensearch.commons.notifications.action.GetChannelListRequest
+import org.opensearch.commons.notifications.action.GetChannelListResponse
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
 import org.opensearch.commons.notifications.action.GetNotificationConfigResponse
 import org.opensearch.commons.notifications.action.GetNotificationEventRequest
@@ -26,7 +26,7 @@ import org.opensearch.commons.notifications.action.LegacyPublishNotificationRequ
 import org.opensearch.commons.notifications.action.LegacyPublishNotificationResponse
 import org.opensearch.commons.notifications.action.NotificationsActions.CREATE_NOTIFICATION_CONFIG_ACTION_TYPE
 import org.opensearch.commons.notifications.action.NotificationsActions.DELETE_NOTIFICATION_CONFIG_ACTION_TYPE
-import org.opensearch.commons.notifications.action.NotificationsActions.GET_FEATURE_CHANNEL_LIST_ACTION_TYPE
+import org.opensearch.commons.notifications.action.NotificationsActions.GET_CHANNEL_LIST_ACTION_TYPE
 import org.opensearch.commons.notifications.action.NotificationsActions.GET_NOTIFICATION_CONFIG_ACTION_TYPE
 import org.opensearch.commons.notifications.action.NotificationsActions.GET_NOTIFICATION_EVENT_ACTION_TYPE
 import org.opensearch.commons.notifications.action.NotificationsActions.GET_PLUGIN_FEATURES_ACTION_TYPE
@@ -156,20 +156,20 @@ object NotificationsPluginInterface {
     }
 
     /**
-     * Get notification channel configuration enabled for a feature.
+     * Get notification channel configuration.
      * @param client Node client for making transport action
      * @param request The request object
      * @param listener The listener for getting response
      */
-    fun getFeatureChannelList(
+    fun getChannelList(
         client: NodeClient,
-        request: GetFeatureChannelListRequest,
-        listener: ActionListener<GetFeatureChannelListResponse>
+        request: GetChannelListRequest,
+        listener: ActionListener<GetChannelListResponse>
     ) {
         client.execute(
-            GET_FEATURE_CHANNEL_LIST_ACTION_TYPE,
+            GET_CHANNEL_LIST_ACTION_TYPE,
             request,
-            wrapActionListener(listener) { response -> recreateObject(response) { GetFeatureChannelListResponse(it) } }
+            wrapActionListener(listener) { response -> recreateObject(response) { GetChannelListResponse(it) } }
         )
     }
 

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/GetChannelListRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/GetChannelListRequest.kt
@@ -21,16 +21,16 @@ import java.io.IOException
 /**
  * This request is plugin-only call. i.e. REST interface is not exposed.
  */
-class GetFeatureChannelListRequest : ActionRequest, ToXContentObject {
+class GetChannelListRequest : ActionRequest, ToXContentObject {
     val compact: Boolean // Dummy request parameter for transport request
 
     companion object {
-        private val log by logger(GetFeatureChannelListRequest::class.java)
+        private val log by logger(GetChannelListRequest::class.java)
 
         /**
          * reader to create instance of class from writable.
          */
-        val reader = Writeable.Reader { GetFeatureChannelListRequest(it) }
+        val reader = Writeable.Reader { GetChannelListRequest(it) }
 
         /**
          * Creator used in REST communication.
@@ -38,7 +38,7 @@ class GetFeatureChannelListRequest : ActionRequest, ToXContentObject {
          */
         @JvmStatic
         @Throws(IOException::class)
-        fun parse(parser: XContentParser): GetFeatureChannelListRequest {
+        fun parse(parser: XContentParser): GetChannelListRequest {
             var compact = false
 
             XContentParserUtils.ensureExpectedToken(
@@ -53,11 +53,11 @@ class GetFeatureChannelListRequest : ActionRequest, ToXContentObject {
                     COMPACT_TAG -> compact = parser.booleanValue()
                     else -> {
                         parser.skipChildren()
-                        log.info("Unexpected field: $fieldName, while parsing GetFeatureChannelListRequest")
+                        log.info("Unexpected field: $fieldName, while parsing GetChannelListRequest")
                     }
                 }
             }
-            return GetFeatureChannelListRequest()
+            return GetChannelListRequest()
         }
     }
 

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/GetChannelListResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/GetChannelListResponse.kt
@@ -10,21 +10,21 @@ import org.opensearch.common.io.stream.Writeable
 import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
-import org.opensearch.commons.notifications.model.FeatureChannelList
+import org.opensearch.commons.notifications.model.ChannelList
 import java.io.IOException
 
 /**
  * Action Response for creating new configuration.
  */
-class GetFeatureChannelListResponse : BaseResponse {
-    val searchResult: FeatureChannelList
+class GetChannelListResponse : BaseResponse {
+    val searchResult: ChannelList
 
     companion object {
 
         /**
          * reader to create instance of class from writable.
          */
-        val reader = Writeable.Reader { GetFeatureChannelListResponse(it) }
+        val reader = Writeable.Reader { GetChannelListResponse(it) }
 
         /**
          * Creator used in REST communication.
@@ -32,8 +32,8 @@ class GetFeatureChannelListResponse : BaseResponse {
          */
         @JvmStatic
         @Throws(IOException::class)
-        fun parse(parser: XContentParser): GetFeatureChannelListResponse {
-            return GetFeatureChannelListResponse(FeatureChannelList(parser))
+        fun parse(parser: XContentParser): GetChannelListResponse {
+            return GetChannelListResponse(ChannelList(parser))
         }
     }
 
@@ -41,7 +41,7 @@ class GetFeatureChannelListResponse : BaseResponse {
      * constructor for creating the class
      * @param searchResult the notification configuration list
      */
-    constructor(searchResult: FeatureChannelList) {
+    constructor(searchResult: ChannelList) {
         this.searchResult = searchResult
     }
 
@@ -50,7 +50,7 @@ class GetFeatureChannelListResponse : BaseResponse {
      */
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
-        searchResult = FeatureChannelList(input)
+        searchResult = ChannelList(input)
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/NotificationsActions.kt
@@ -43,7 +43,7 @@ object NotificationsActions {
     /**
      * Get Config List for feature. Internal only - Inter plugin communication.
      */
-    const val GET_FEATURE_CHANNEL_LIST_NAME = "cluster:admin/opensearch/notifications/feature/channels/get"
+    const val GET_CHANNEL_LIST_NAME = "cluster:admin/opensearch/notifications/channels/get"
 
     /**
      * Send notification message. Internal only - Inter plugin communication.
@@ -93,10 +93,10 @@ object NotificationsActions {
         ActionType(GET_PLUGIN_FEATURES_NAME, ::GetPluginFeaturesResponse)
 
     /**
-     * Get Config List for feature transport action type.
+     * Get notification channel List transport action type.
      */
-    val GET_FEATURE_CHANNEL_LIST_ACTION_TYPE =
-        ActionType(GET_FEATURE_CHANNEL_LIST_NAME, ::GetFeatureChannelListResponse)
+    val GET_CHANNEL_LIST_ACTION_TYPE =
+        ActionType(GET_CHANNEL_LIST_NAME, ::GetChannelListResponse)
 
     /**
      * Send notification transport action type. Internal only - Inter plugin communication.

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Channel.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Channel.kt
@@ -21,9 +21,9 @@ import org.opensearch.commons.utils.logger
 import java.io.IOException
 
 /**
- * Data class representing Notification config for exposed for other plugins.
+ * Data class representing Notification config exposed for other plugins.
  */
-data class FeatureChannel(
+data class Channel(
     val configId: String,
     val name: String,
     val description: String,
@@ -37,12 +37,12 @@ data class FeatureChannel(
     }
 
     companion object {
-        private val log by logger(FeatureChannel::class.java)
+        private val log by logger(Channel::class.java)
 
         /**
          * reader to create instance of class from writable.
          */
-        val reader = Writeable.Reader { FeatureChannel(it) }
+        val reader = Writeable.Reader { Channel(it) }
 
         /**
          * Creator used in REST communication.
@@ -51,7 +51,7 @@ data class FeatureChannel(
         @Suppress("ComplexMethod")
         @JvmStatic
         @Throws(IOException::class)
-        fun parse(parser: XContentParser): FeatureChannel {
+        fun parse(parser: XContentParser): Channel {
             var configId: String? = null
             var name: String? = null
             var description = ""
@@ -74,14 +74,14 @@ data class FeatureChannel(
                     IS_ENABLED_TAG -> isEnabled = parser.booleanValue()
                     else -> {
                         parser.skipChildren()
-                        log.info("Unexpected field: $fieldName, while parsing FeatureChannel")
+                        log.info("Unexpected field: $fieldName, while parsing Channel")
                     }
                 }
             }
             configId ?: throw IllegalArgumentException("$CONFIG_ID_TAG field absent")
             name ?: throw IllegalArgumentException("$NAME_TAG field absent")
             configType ?: throw IllegalArgumentException("$CONFIG_TYPE_TAG field absent")
-            return FeatureChannel(
+            return Channel(
                 configId,
                 name,
                 description,

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/ChannelList.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/ChannelList.kt
@@ -9,22 +9,22 @@ import org.apache.lucene.search.TotalHits
 import org.opensearch.action.search.SearchResponse
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.xcontent.XContentParser
-import org.opensearch.commons.notifications.NotificationConstants.FEATURE_CONFIG_LIST_TAG
+import org.opensearch.commons.notifications.NotificationConstants.CHANNEL_LIST_TAG
 
 /**
- * FeatureChannel search results
+ * Channel search results
  */
-class FeatureChannelList : SearchResults<FeatureChannel> {
+class ChannelList : SearchResults<Channel> {
 
     /**
      * single item result constructor
      */
-    constructor(objectItem: FeatureChannel) : super(FEATURE_CONFIG_LIST_TAG, objectItem)
+    constructor(objectItem: Channel) : super(CHANNEL_LIST_TAG, objectItem)
 
     /**
      * multiple items result constructor
      */
-    constructor(objectList: List<FeatureChannel>) : this(
+    constructor(objectList: List<Channel>) : this(
         0,
         objectList.size.toLong(),
         TotalHits.Relation.EQUAL_TO,
@@ -38,34 +38,34 @@ class FeatureChannelList : SearchResults<FeatureChannel> {
         startIndex: Long,
         totalHits: Long,
         totalHitRelation: TotalHits.Relation,
-        objectList: List<FeatureChannel>
-    ) : super(startIndex, totalHits, totalHitRelation, FEATURE_CONFIG_LIST_TAG, objectList)
+        objectList: List<Channel>
+    ) : super(startIndex, totalHits, totalHitRelation, CHANNEL_LIST_TAG, objectList)
 
     /**
      * Constructor used in transport action communication.
      * @param input StreamInput stream to deserialize data from.
      */
-    constructor(input: StreamInput) : super(input, FeatureChannel.reader)
+    constructor(input: StreamInput) : super(input, Channel.reader)
 
     /**
      * Construct object from XContentParser
      */
-    constructor(parser: XContentParser) : super(parser, FEATURE_CONFIG_LIST_TAG)
+    constructor(parser: XContentParser) : super(parser, CHANNEL_LIST_TAG)
 
     /**
      * Construct object from SearchResponse
      */
-    constructor(from: Long, response: SearchResponse, searchHitParser: SearchHitParser<FeatureChannel>) : super(
+    constructor(from: Long, response: SearchResponse, searchHitParser: SearchHitParser<Channel>) : super(
         from,
         response,
         searchHitParser,
-        FEATURE_CONFIG_LIST_TAG
+        CHANNEL_LIST_TAG
     )
 
     /**
      * {@inheritDoc}
      */
-    override fun parseItem(parser: XContentParser): FeatureChannel {
-        return FeatureChannel.parse(parser)
+    override fun parseItem(parser: XContentParser): Channel {
+        return Channel.parse(parser)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -25,8 +25,8 @@ import org.opensearch.commons.notifications.action.CreateNotificationConfigReque
 import org.opensearch.commons.notifications.action.CreateNotificationConfigResponse
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigRequest
 import org.opensearch.commons.notifications.action.DeleteNotificationConfigResponse
-import org.opensearch.commons.notifications.action.GetFeatureChannelListRequest
-import org.opensearch.commons.notifications.action.GetFeatureChannelListResponse
+import org.opensearch.commons.notifications.action.GetChannelListRequest
+import org.opensearch.commons.notifications.action.GetChannelListResponse
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
 import org.opensearch.commons.notifications.action.GetNotificationConfigResponse
 import org.opensearch.commons.notifications.action.GetNotificationEventRequest
@@ -38,13 +38,13 @@ import org.opensearch.commons.notifications.action.LegacyPublishNotificationResp
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
+import org.opensearch.commons.notifications.model.Channel
+import org.opensearch.commons.notifications.model.ChannelList
 import org.opensearch.commons.notifications.model.ChannelMessage
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.DeliveryStatus
 import org.opensearch.commons.notifications.model.EventSource
 import org.opensearch.commons.notifications.model.EventStatus
-import org.opensearch.commons.notifications.model.FeatureChannel
-import org.opensearch.commons.notifications.model.FeatureChannelList
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.NotificationConfigSearchResult
@@ -168,25 +168,25 @@ internal class NotificationsPluginInterfaceTests {
     }
 
     @Test
-    fun getFeatureChannelList() {
-        val sampleConfig = FeatureChannel(
+    fun getChannelList() {
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.SLACK
         )
 
-        val request = mock(GetFeatureChannelListRequest::class.java)
-        val response = GetFeatureChannelListResponse(FeatureChannelList(sampleConfig))
-        val listener: ActionListener<GetFeatureChannelListResponse> =
-            mock(ActionListener::class.java) as ActionListener<GetFeatureChannelListResponse>
+        val request = mock(GetChannelListRequest::class.java)
+        val response = GetChannelListResponse(ChannelList(sampleConfig))
+        val listener: ActionListener<GetChannelListResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetChannelListResponse>
 
         doAnswer {
-            (it.getArgument(2) as ActionListener<GetFeatureChannelListResponse>)
+            (it.getArgument(2) as ActionListener<GetChannelListResponse>)
                 .onResponse(response)
         }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
-        NotificationsPluginInterface.getFeatureChannelList(client, request, listener)
+        NotificationsPluginInterface.getChannelList(client, request, listener)
         verify(listener, times(1)).onResponse(eq(response))
     }
 

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetChannelListRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetChannelListRequestTests.kt
@@ -12,27 +12,27 @@ import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
 
-internal class GetFeatureChannelListRequestTests {
+internal class GetChannelListRequestTests {
 
     private fun assertGetRequestEquals(
-        expected: GetFeatureChannelListRequest,
-        actual: GetFeatureChannelListRequest
+        expected: GetChannelListRequest,
+        actual: GetChannelListRequest
     ) {
         assertEquals(expected.compact, actual.compact)
     }
 
     @Test
     fun `Get request serialize and deserialize transport object should be equal`() {
-        val configRequest = GetFeatureChannelListRequest()
-        val recreatedObject = recreateObject(configRequest) { GetFeatureChannelListRequest(it) }
+        val configRequest = GetChannelListRequest()
+        val recreatedObject = recreateObject(configRequest) { GetChannelListRequest(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
     }
 
     @Test
     fun `Get request serialize and deserialize using json object should be equal`() {
-        val configRequest = GetFeatureChannelListRequest()
+        val configRequest = GetChannelListRequest()
         val jsonString = getJsonString(configRequest)
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListRequest.parse(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
     }
 
@@ -40,13 +40,13 @@ internal class GetFeatureChannelListRequestTests {
     fun `Get request should throw exception when invalid json object is passed`() {
         val jsonString = "sample message"
         assertThrows<JsonParseException> {
-            createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
+            createObjectFromJsonString(jsonString) { GetChannelListRequest.parse(it) }
         }
     }
 
     @Test
     fun `Get request should safely ignore extra field in json object`() {
-        val configRequest = GetFeatureChannelListRequest()
+        val configRequest = GetChannelListRequest()
         val jsonString = """
         {
             "extra_field_1":["extra", "value"],
@@ -54,7 +54,7 @@ internal class GetFeatureChannelListRequestTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListRequest.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListRequest.parse(it) }
         assertGetRequestEquals(configRequest, recreatedObject)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetChannelListResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetChannelListResponseTests.kt
@@ -8,18 +8,18 @@ import org.apache.lucene.search.TotalHits
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.opensearch.commons.notifications.model.Channel
+import org.opensearch.commons.notifications.model.ChannelList
 import org.opensearch.commons.notifications.model.ConfigType
-import org.opensearch.commons.notifications.model.FeatureChannel
-import org.opensearch.commons.notifications.model.FeatureChannelList
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
 
-internal class GetFeatureChannelListResponseTests {
+internal class GetChannelListResponseTests {
 
     private fun assertSearchResultEquals(
-        expected: FeatureChannelList,
-        actual: FeatureChannelList
+        expected: ChannelList,
+        actual: ChannelList
     ) {
         assertEquals(expected.startIndex, actual.startIndex)
         assertEquals(expected.totalHits, actual.totalHits)
@@ -30,112 +30,112 @@ internal class GetFeatureChannelListResponseTests {
 
     @Test
     fun `Get Response serialize and deserialize with config object should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.SLACK
         )
-        val searchResult = FeatureChannelList(sampleConfig)
-        val getResponse = GetFeatureChannelListResponse(searchResult)
-        val recreatedObject = recreateObject(getResponse) { GetFeatureChannelListResponse(it) }
+        val searchResult = ChannelList(sampleConfig)
+        val getResponse = GetChannelListResponse(searchResult)
+        val recreatedObject = recreateObject(getResponse) { GetChannelListResponse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response serialize and deserialize with multiple config object should be equal`() {
-        val sampleConfig1 = FeatureChannel(
+        val sampleConfig1 = Channel(
             "config_id1",
             "name1",
             "description1",
             ConfigType.SLACK
         )
-        val sampleConfig2 = FeatureChannel(
+        val sampleConfig2 = Channel(
             "config_id2",
             "name2",
             "description2",
             ConfigType.CHIME
         )
-        val sampleConfig3 = FeatureChannel(
+        val sampleConfig3 = Channel(
             "config_id3",
             "name3",
             "description3",
             ConfigType.WEBHOOK
         )
-        val searchResult = FeatureChannelList(
+        val searchResult = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
             listOf(sampleConfig1, sampleConfig2, sampleConfig3)
         )
-        val getResponse = GetFeatureChannelListResponse(searchResult)
-        val recreatedObject = recreateObject(getResponse) { GetFeatureChannelListResponse(it) }
+        val getResponse = GetChannelListResponse(searchResult)
+        val recreatedObject = recreateObject(getResponse) { GetChannelListResponse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response serialize and deserialize using json config object should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL_GROUP
         )
-        val searchResult = FeatureChannelList(sampleConfig)
-        val getResponse = GetFeatureChannelListResponse(searchResult)
+        val searchResult = ChannelList(sampleConfig)
+        val getResponse = GetChannelListResponse(searchResult)
         val jsonString = getJsonString(getResponse)
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response serialize and deserialize using json with multiple config object should be equal`() {
-        val sampleConfig1 = FeatureChannel(
+        val sampleConfig1 = Channel(
             "config_id1",
             "name1",
             "description1",
             ConfigType.SLACK
         )
-        val sampleConfig2 = FeatureChannel(
+        val sampleConfig2 = Channel(
             "config_id2",
             "name2",
             "description2",
             ConfigType.CHIME
         )
-        val sampleConfig3 = FeatureChannel(
+        val sampleConfig3 = Channel(
             "config_id3",
             "name3",
             "description3",
             ConfigType.WEBHOOK
         )
-        val searchResult = FeatureChannelList(
+        val searchResult = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
             listOf(sampleConfig1, sampleConfig2, sampleConfig3)
         )
-        val getResponse = GetFeatureChannelListResponse(searchResult)
+        val getResponse = GetChannelListResponse(searchResult)
         val jsonString = getJsonString(getResponse)
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response should use isEnabled=true if absent in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL,
             true
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
             "start_index":"0",
             "total_hits":"1",
             "total_hit_relation":"eq",
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -145,25 +145,25 @@ internal class GetFeatureChannelListResponseTests {
             ]
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response should safely ignore extra field in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
             "start_index":"0",
             "total_hits":"1",
             "total_hit_relation":"eq",
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -177,22 +177,22 @@ internal class GetFeatureChannelListResponseTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
     fun `Get Response should safely fallback to default if startIndex, totalHits or totalHitRelation field absent in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -203,12 +203,12 @@ internal class GetFeatureChannelListResponseTests {
             ]
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         assertSearchResultEquals(searchResult, recreatedObject.searchResult)
     }
 
     @Test
-    fun `Get Response should throw exception if featureChannelList is absent in json`() {
+    fun `Get Response should throw exception if channelList is absent in json`() {
         val jsonString = """
         {
             "start_index":"0",
@@ -217,7 +217,7 @@ internal class GetFeatureChannelListResponseTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { GetFeatureChannelListResponse.parse(it) }
+            createObjectFromJsonString(jsonString) { GetChannelListResponse.parse(it) }
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/ChannelListTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/ChannelListTests.kt
@@ -12,11 +12,11 @@ import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
 
-internal class FeatureChannelListTests {
+internal class ChannelListTests {
 
     private fun assertSearchResultEquals(
-        expected: FeatureChannelList,
-        actual: FeatureChannelList
+        expected: ChannelList,
+        actual: ChannelList
     ) {
         assertEquals(expected.startIndex, actual.startIndex)
         assertEquals(expected.totalHits, actual.totalHits)
@@ -27,129 +27,129 @@ internal class FeatureChannelListTests {
 
     @Test
     fun `Feature Channel List serialize and deserialize using transport should be equal`() {
-        val featureChannel = FeatureChannel(
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.SLACK,
             true
         )
-        val featureChannelList = FeatureChannelList(featureChannel)
-        val recreatedObject = recreateObject(featureChannelList) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val channelList = ChannelList(channel)
+        val recreatedObject = recreateObject(channelList) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List serialize and deserialize multiple object with default values should be equal`() {
-        val featureChannel1 = FeatureChannel(
+        val channel1 = Channel(
             "configId1",
             "name1",
             "description1",
             ConfigType.SLACK,
             true
         )
-        val featureChannel2 = FeatureChannel(
+        val channel2 = Channel(
             "configId2",
             "name2",
             "description2",
             ConfigType.CHIME,
             true
         )
-        val featureChannelList = FeatureChannelList(listOf(featureChannel1, featureChannel2))
-        val expectedResult = FeatureChannelList(
+        val channelList = ChannelList(listOf(channel1, channel2))
+        val expectedResult = ChannelList(
             0,
             2,
             TotalHits.Relation.EQUAL_TO,
-            listOf(featureChannel1, featureChannel2)
+            listOf(channel1, channel2)
         )
-        val recreatedObject = recreateObject(featureChannelList) { FeatureChannelList(it) }
+        val recreatedObject = recreateObject(channelList) { ChannelList(it) }
         assertSearchResultEquals(expectedResult, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List serialize and deserialize with multiple object should be equal`() {
-        val featureChannel1 = FeatureChannel(
+        val channel1 = Channel(
             "configId1",
             "name1",
             "description1",
             ConfigType.SLACK,
             true
         )
-        val featureChannel2 = FeatureChannel(
+        val channel2 = Channel(
             "configId2",
             "name2",
             "description2",
             ConfigType.CHIME,
             true
         )
-        val featureChannelList = FeatureChannelList(
+        val channelList = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
-            listOf(featureChannel1, featureChannel2)
+            listOf(channel1, channel2)
         )
-        val recreatedObject = recreateObject(featureChannelList) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val recreatedObject = recreateObject(channelList) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List serialize and deserialize using json should be equal`() {
-        val featureChannel = FeatureChannel(
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.SLACK,
             true
         )
-        val featureChannelList = FeatureChannelList(featureChannel)
-        val jsonString = getJsonString(featureChannelList)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val channelList = ChannelList(channel)
+        val jsonString = getJsonString(channelList)
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List serialize and deserialize using json with multiple object should be equal`() {
-        val featureChannel1 = FeatureChannel(
+        val channel1 = Channel(
             "configId1",
             "name1",
             "description1",
             ConfigType.SLACK,
             true
         )
-        val featureChannel2 = FeatureChannel(
+        val channel2 = Channel(
             "configId2",
             "name2",
             "description2",
             ConfigType.CHIME,
             true
         )
-        val featureChannelList = FeatureChannelList(
+        val channelList = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
-            listOf(featureChannel1, featureChannel2)
+            listOf(channel1, channel2)
         )
-        val jsonString = getJsonString(featureChannelList)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val jsonString = getJsonString(channelList)
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List should safely ignore extra field in json object`() {
-        val featureChannel = FeatureChannel(
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.SLACK,
             true
         )
-        val featureChannelList = FeatureChannelList(featureChannel)
+        val channelList = ChannelList(channel)
         val jsonString = """
         {
             "start_index":"0",
             "total_hits":"1",
             "total_hit_relation":"eq",
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"configId",
                     "name":"name",
@@ -163,23 +163,23 @@ internal class FeatureChannelListTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
     fun `Feature Channel List should safely fallback to default if startIndex, totalHits or totalHitRelation field absent in json object`() {
-        val featureChannel = FeatureChannel(
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.SLACK,
             true
         )
-        val featureChannelList = FeatureChannelList(featureChannel)
+        val channelList = ChannelList(channel)
         val jsonString = """
         {
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"configId",
                     "name":"name",
@@ -190,12 +190,12 @@ internal class FeatureChannelListTests {
             ]
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
-        assertSearchResultEquals(featureChannelList, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
+        assertSearchResultEquals(channelList, recreatedObject)
     }
 
     @Test
-    fun `Feature Channel List should throw exception if feature_channel_list is absent in json`() {
+    fun `Channel List should throw exception if channel_list is absent in json`() {
         val jsonString = """
         {
             "start_index":"0",
@@ -204,7 +204,7 @@ internal class FeatureChannelListTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+            createObjectFromJsonString(jsonString) { ChannelList(it) }
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/ChannelTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/ChannelTests.kt
@@ -11,38 +11,38 @@ import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
 import org.opensearch.commons.utils.recreateObject
 
-internal class FeatureChannelTests {
+internal class ChannelTests {
 
     @Test
-    fun `FeatureChannel Object serialize and deserialize using transport should be equal`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Object serialize and deserialize using transport should be equal`() {
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.SLACK,
             true
         )
-        val recreatedObject = recreateObject(featureChannel) { FeatureChannel(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val recreatedObject = recreateObject(channel) { Channel(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Object serialize and deserialize using json should be equal`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Object serialize and deserialize using json should be equal`() {
+        val channel = Channel(
             "configId",
             "name",
             "description",
             ConfigType.CHIME,
             false
         )
-        val jsonString = getJsonString(featureChannel)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val jsonString = getJsonString(channel)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Json parsing should safely ignore extra fields`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Json parsing should safely ignore extra fields`() {
+        val channel = Channel(
             "configId",
             "name",
             "description",
@@ -61,13 +61,13 @@ internal class FeatureChannelTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Json parsing should safely ignore unknown config type`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Json parsing should safely ignore unknown config type`() {
+        val channel = Channel(
             "configId",
             "name",
             "description",
@@ -83,13 +83,13 @@ internal class FeatureChannelTests {
             "is_enabled":true
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Json parsing should safely parse if description is absent`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Json parsing should safely parse if description is absent`() {
+        val channel = Channel(
             "configId",
             "name",
             "",
@@ -104,13 +104,13 @@ internal class FeatureChannelTests {
             "is_enabled":true
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Json parsing should safely parse if is_enabled is absent`() {
-        val featureChannel = FeatureChannel(
+    fun `Channel Json parsing should safely parse if is_enabled is absent`() {
+        val channel = Channel(
             "configId",
             "name",
             "description",
@@ -125,12 +125,12 @@ internal class FeatureChannelTests {
             "config_type":"slack"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
-        assertEquals(featureChannel, recreatedObject)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
+        assertEquals(channel, recreatedObject)
     }
 
     @Test
-    fun `FeatureChannel Json parsing should throw exception if config_id is absent`() {
+    fun `Channel Json parsing should throw exception if config_id is absent`() {
         val jsonString = """
         {
             "name":"name",
@@ -140,12 +140,12 @@ internal class FeatureChannelTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+            createObjectFromJsonString(jsonString) { Channel.parse(it) }
         }
     }
 
     @Test
-    fun `FeatureChannel Json parsing should throw exception if config_id is empty`() {
+    fun `Channel Json parsing should throw exception if config_id is empty`() {
         val jsonString = """
         {
             "config_id":"",
@@ -156,12 +156,12 @@ internal class FeatureChannelTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+            createObjectFromJsonString(jsonString) { Channel.parse(it) }
         }
     }
 
     @Test
-    fun `FeatureChannel Json parsing should throw exception if name is absent`() {
+    fun `Channel Json parsing should throw exception if name is absent`() {
         val jsonString = """
         {
             "config_id":"configId",
@@ -171,12 +171,12 @@ internal class FeatureChannelTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+            createObjectFromJsonString(jsonString) { Channel.parse(it) }
         }
     }
 
     @Test
-    fun `FeatureChannel Json parsing should throw exception if name is empty`() {
+    fun `Channel Json parsing should throw exception if name is empty`() {
         val jsonString = """
         {
             "config_id":"configId",
@@ -187,12 +187,12 @@ internal class FeatureChannelTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+            createObjectFromJsonString(jsonString) { Channel.parse(it) }
         }
     }
 
     @Test
-    fun `FeatureChannel Json parsing should throw exception if config_type is absent`() {
+    fun `Channel Json parsing should throw exception if config_type is absent`() {
         val jsonString = """
         {
             "config_id":"configId",
@@ -202,7 +202,7 @@ internal class FeatureChannelTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+            createObjectFromJsonString(jsonString) { Channel.parse(it) }
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/FilterConfigListTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/FilterConfigListTests.kt
@@ -15,8 +15,8 @@ import org.opensearch.commons.utils.recreateObject
 internal class FilterConfigListTests {
 
     private fun assertSearchResultEquals(
-        expected: FeatureChannelList,
-        actual: FeatureChannelList
+        expected: ChannelList,
+        actual: ChannelList
     ) {
         assertEquals(expected.startIndex, actual.startIndex)
         assertEquals(expected.totalHits, actual.totalHits)
@@ -27,108 +27,108 @@ internal class FilterConfigListTests {
 
     @Test
     fun `Search result serialize and deserialize with config object should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.SLACK
         )
-        val searchResult = FeatureChannelList(sampleConfig)
-        val recreatedObject = recreateObject(searchResult) { FeatureChannelList(it) }
+        val searchResult = ChannelList(sampleConfig)
+        val recreatedObject = recreateObject(searchResult) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result serialize and deserialize with multiple config object should be equal`() {
-        val sampleConfig1 = FeatureChannel(
+        val sampleConfig1 = Channel(
             "config_id1",
             "name1",
             "description1",
             ConfigType.SLACK
         )
-        val sampleConfig2 = FeatureChannel(
+        val sampleConfig2 = Channel(
             "config_id2",
             "name2",
             "description2",
             ConfigType.CHIME
         )
-        val sampleConfig3 = FeatureChannel(
+        val sampleConfig3 = Channel(
             "config_id3",
             "name3",
             "description3",
             ConfigType.WEBHOOK
         )
-        val searchResult = FeatureChannelList(
+        val searchResult = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
             listOf(sampleConfig1, sampleConfig2, sampleConfig3)
         )
-        val recreatedObject = recreateObject(searchResult) { FeatureChannelList(it) }
+        val recreatedObject = recreateObject(searchResult) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result serialize and deserialize using json config object should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL_GROUP
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = getJsonString(searchResult)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result serialize and deserialize using json with multiple config object should be equal`() {
-        val sampleConfig1 = FeatureChannel(
+        val sampleConfig1 = Channel(
             "config_id1",
             "name1",
             "description1",
             ConfigType.SLACK
         )
-        val sampleConfig2 = FeatureChannel(
+        val sampleConfig2 = Channel(
             "config_id2",
             "name2",
             "description2",
             ConfigType.CHIME
         )
-        val sampleConfig3 = FeatureChannel(
+        val sampleConfig3 = Channel(
             "config_id3",
             "name3",
             "description3",
             ConfigType.WEBHOOK
         )
-        val searchResult = FeatureChannelList(
+        val searchResult = ChannelList(
             100,
             1000,
             TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO,
             listOf(sampleConfig1, sampleConfig2, sampleConfig3)
         )
         val jsonString = getJsonString(searchResult)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result should use isEnabled=true if absent in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL,
             true
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
             "start_index":"0",
             "total_hits":"1",
             "total_hit_relation":"eq",
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -138,25 +138,25 @@ internal class FilterConfigListTests {
             ]
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result should safely ignore extra field in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
             "start_index":"0",
             "total_hits":"1",
             "total_hit_relation":"eq",
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -170,22 +170,22 @@ internal class FilterConfigListTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
     fun `Search result should safely fallback to default if startIndex, totalHits or totalHitRelation field absent in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.EMAIL
         )
-        val searchResult = FeatureChannelList(sampleConfig)
+        val searchResult = ChannelList(sampleConfig)
         val jsonString = """
         {
-            "feature_channel_list":[
+            "channel_list":[
                 {
                     "config_id":"config_id",
                     "name":"name",
@@ -196,12 +196,12 @@ internal class FilterConfigListTests {
             ]
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { ChannelList(it) }
         assertSearchResultEquals(searchResult, recreatedObject)
     }
 
     @Test
-    fun `Search result should throw exception if featureChannelList is absent in json`() {
+    fun `Search result should throw exception if channelList is absent in json`() {
         val jsonString = """
         {
             "start_index":"0",
@@ -210,7 +210,7 @@ internal class FilterConfigListTests {
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { FeatureChannelList(it) }
+            createObjectFromJsonString(jsonString) { ChannelList(it) }
         }
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/FilterConfigTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/FilterConfigTests.kt
@@ -15,45 +15,45 @@ internal class FilterConfigTests {
 
     @Test
     fun `Config serialize and deserialize with default isEnabled flag should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.SLACK
         )
-        val recreatedObject = recreateObject(sampleConfig) { FeatureChannel(it) }
+        val recreatedObject = recreateObject(sampleConfig) { Channel(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config serialize and deserialize with isEnabled=false should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.CHIME,
             false
         )
-        val recreatedObject = recreateObject(sampleConfig) { FeatureChannel(it) }
+        val recreatedObject = recreateObject(sampleConfig) { Channel(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config serialize and deserialize using json object with default isEnabled flag should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
             ConfigType.WEBHOOK
         )
         val jsonString = getJsonString(sampleConfig)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config serialize and deserialize using json object with isEnabled=false should be equal`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
@@ -61,13 +61,13 @@ internal class FilterConfigTests {
             false
         )
         val jsonString = getJsonString(sampleConfig)
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config should safely ignore extra field in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
@@ -85,13 +85,13 @@ internal class FilterConfigTests {
             "extra_field_3":"extra value 3"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config should safely ignore unknown config type in json object`() {
-        val sampleConfig = FeatureChannel(
+        val sampleConfig = Channel(
             "config_id",
             "name",
             "description",
@@ -105,14 +105,14 @@ internal class FilterConfigTests {
             "config_type":"NewConfig"
         }
         """.trimIndent()
-        val recreatedObject = createObjectFromJsonString(jsonString) { FeatureChannel.parse(it) }
+        val recreatedObject = createObjectFromJsonString(jsonString) { Channel.parse(it) }
         assertEquals(sampleConfig, recreatedObject)
     }
 
     @Test
     fun `Config throw exception if configId is empty`() {
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            FeatureChannel(
+            Channel(
                 "",
                 "name",
                 "description",
@@ -124,7 +124,7 @@ internal class FilterConfigTests {
     @Test
     fun `Config throw exception if name is empty`() {
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            FeatureChannel(
+            Channel(
                 "config_id",
                 "",
                 "description",


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Renaming FeatureChannels, FeatureChannelList, etc. to remove "Feature" references to be more consistent with the API since it does not relate to features after recent changes.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
