### PR TITLE
Remove allowedConfigFeatureList from GetPluginFeaturesResponse for Notifications

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
@@ -66,7 +66,6 @@ object NotificationConstants {
     const val QUERY_TAG = "query"
     const val COMPACT_TAG = "compact"
     const val ALLOWED_CONFIG_TYPE_LIST_TAG = "allowed_config_type_list"
-    const val ALLOWED_CONFIG_FEATURE_LIST_TAG = "allowed_config_feature_list"
     const val PLUGIN_FEATURES_TAG = "plugin_features"
 
     const val DEFAULT_MAX_ITEMS = 1000

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/GetPluginFeaturesResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/GetPluginFeaturesResponse.kt
@@ -11,7 +11,6 @@ import org.opensearch.common.xcontent.ToXContent
 import org.opensearch.common.xcontent.XContentBuilder
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
-import org.opensearch.commons.notifications.NotificationConstants.ALLOWED_CONFIG_FEATURE_LIST_TAG
 import org.opensearch.commons.notifications.NotificationConstants.ALLOWED_CONFIG_TYPE_LIST_TAG
 import org.opensearch.commons.notifications.NotificationConstants.PLUGIN_FEATURES_TAG
 import org.opensearch.commons.utils.STRING_READER
@@ -25,7 +24,6 @@ import java.io.IOException
  */
 class GetPluginFeaturesResponse : BaseResponse {
     val allowedConfigTypeList: List<String>
-    val allowedConfigFeatureList: List<String>
     val pluginFeatures: Map<String, String>
 
     companion object {
@@ -44,7 +42,6 @@ class GetPluginFeaturesResponse : BaseResponse {
         @Throws(IOException::class)
         fun parse(parser: XContentParser): GetPluginFeaturesResponse {
             var allowedConfigTypeList: List<String>? = null
-            var allowedConfigFeatureList: List<String>? = null
             var pluginFeatures: Map<String, String>? = null
 
             XContentParserUtils.ensureExpectedToken(
@@ -57,7 +54,6 @@ class GetPluginFeaturesResponse : BaseResponse {
                 parser.nextToken()
                 when (fieldName) {
                     ALLOWED_CONFIG_TYPE_LIST_TAG -> allowedConfigTypeList = parser.stringList()
-                    ALLOWED_CONFIG_FEATURE_LIST_TAG -> allowedConfigFeatureList = parser.stringList()
                     PLUGIN_FEATURES_TAG -> pluginFeatures = parser.mapStrings()
                     else -> {
                         parser.skipChildren()
@@ -66,9 +62,8 @@ class GetPluginFeaturesResponse : BaseResponse {
                 }
             }
             allowedConfigTypeList ?: throw IllegalArgumentException("$ALLOWED_CONFIG_TYPE_LIST_TAG field absent")
-            allowedConfigFeatureList ?: throw IllegalArgumentException("$ALLOWED_CONFIG_TYPE_LIST_TAG field absent")
             pluginFeatures ?: throw IllegalArgumentException("$PLUGIN_FEATURES_TAG field absent")
-            return GetPluginFeaturesResponse(allowedConfigTypeList, allowedConfigFeatureList, pluginFeatures)
+            return GetPluginFeaturesResponse(allowedConfigTypeList, pluginFeatures)
         }
     }
 
@@ -78,7 +73,6 @@ class GetPluginFeaturesResponse : BaseResponse {
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
         return builder!!.startObject()
             .field(ALLOWED_CONFIG_TYPE_LIST_TAG, allowedConfigTypeList)
-            .field(ALLOWED_CONFIG_FEATURE_LIST_TAG, allowedConfigFeatureList)
             .field(PLUGIN_FEATURES_TAG, pluginFeatures)
             .endObject()
     }
@@ -86,16 +80,13 @@ class GetPluginFeaturesResponse : BaseResponse {
     /**
      * constructor for creating the class
      * @param allowedConfigTypeList the list of config types supported by plugin
-     * @param allowedConfigFeatureList the list of config features supported by plugin
      * @param pluginFeatures the map of plugin features supported to its value
      */
     constructor(
         allowedConfigTypeList: List<String>,
-        allowedConfigFeatureList: List<String>,
         pluginFeatures: Map<String, String>
     ) {
         this.allowedConfigTypeList = allowedConfigTypeList
-        this.allowedConfigFeatureList = allowedConfigFeatureList
         this.pluginFeatures = pluginFeatures
     }
 
@@ -105,7 +96,6 @@ class GetPluginFeaturesResponse : BaseResponse {
     @Throws(IOException::class)
     constructor(input: StreamInput) : super(input) {
         allowedConfigTypeList = input.readStringList()
-        allowedConfigFeatureList = input.readStringList()
         pluginFeatures = input.readMap(STRING_READER, STRING_READER)
     }
 
@@ -115,7 +105,6 @@ class GetPluginFeaturesResponse : BaseResponse {
     @Throws(IOException::class)
     override fun writeTo(output: StreamOutput) {
         output.writeStringCollection(allowedConfigTypeList)
-        output.writeStringCollection(allowedConfigFeatureList)
         output.writeMap(pluginFeatures, STRING_WRITER, STRING_WRITER)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -148,7 +148,6 @@ internal class NotificationsPluginInterfaceTests {
         val request = mock(GetPluginFeaturesRequest::class.java)
         val response = GetPluginFeaturesResponse(
             listOf("config_type_1", "config_type_2", "config_type_3"),
-            listOf("config_feature_1", "config_feature_2", "config_feature_3"),
             mapOf(
                 Pair("FeatureKey1", "FeatureValue1"),
                 Pair("FeatureKey2", "FeatureValue2"),

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/GetPluginFeaturesResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/GetPluginFeaturesResponseTests.kt
@@ -18,7 +18,6 @@ internal class GetPluginFeaturesResponseTests {
         actual: GetPluginFeaturesResponse
     ) {
         assertEquals(expected.allowedConfigTypeList, actual.allowedConfigTypeList)
-        assertEquals(expected.allowedConfigFeatureList, actual.allowedConfigFeatureList)
         assertEquals(expected.pluginFeatures, actual.pluginFeatures)
     }
 
@@ -26,7 +25,6 @@ internal class GetPluginFeaturesResponseTests {
     fun `Get Response serialize and deserialize transport object should be equal`() {
         val response = GetPluginFeaturesResponse(
             listOf("config_type_1", "config_type_2", "config_type_3"),
-            listOf("config_feature_1", "config_feature_2", "config_feature_3"),
             mapOf(
                 Pair("FeatureKey1", "FeatureValue1"),
                 Pair("FeatureKey2", "FeatureValue2"),
@@ -41,7 +39,6 @@ internal class GetPluginFeaturesResponseTests {
     fun `Get Response serialize and deserialize using json config object should be equal`() {
         val response = GetPluginFeaturesResponse(
             listOf("config_type_1", "config_type_2", "config_type_3"),
-            listOf("config_feature_1", "config_feature_2", "config_feature_3"),
             mapOf(
                 Pair("FeatureKey1", "FeatureValue1"),
                 Pair("FeatureKey2", "FeatureValue2"),
@@ -57,7 +54,6 @@ internal class GetPluginFeaturesResponseTests {
     fun `Get Response should safely ignore extra field in json object`() {
         val response = GetPluginFeaturesResponse(
             listOf("config_type_1", "config_type_2", "config_type_3"),
-            listOf("config_feature_1", "config_feature_2", "config_feature_3"),
             mapOf(
                 Pair("FeatureKey1", "FeatureValue1"),
                 Pair("FeatureKey2", "FeatureValue2"),
@@ -67,7 +63,6 @@ internal class GetPluginFeaturesResponseTests {
         val jsonString = """
         {
             "allowed_config_type_list":["config_type_1", "config_type_2", "config_type_3"],
-            "allowed_config_feature_list":["config_feature_1", "config_feature_2", "config_feature_3"],
             "plugin_features":{
                 "FeatureKey1":"FeatureValue1",
                 "FeatureKey2":"FeatureValue2",
@@ -86,24 +81,6 @@ internal class GetPluginFeaturesResponseTests {
     fun `Get Response should throw exception if allowed_config_type_list is absent in json`() {
         val jsonString = """
         {
-            "allowed_config_feature_list":["config_feature_1", "config_feature_2", "config_feature_3"],
-            "plugin_features":{
-                "FeatureKey1":"FeatureValue1",
-                "FeatureKey2":"FeatureValue2",
-                "FeatureKey3":"FeatureValue3"
-            }
-        }
-        """.trimIndent()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            createObjectFromJsonString(jsonString) { GetPluginFeaturesResponse.parse(it) }
-        }
-    }
-
-    @Test
-    fun `Get Response should throw exception if allowed_config_feature_list is absent in json`() {
-        val jsonString = """
-        {
-            "allowed_config_type_list":["config_type_1", "config_type_2", "config_type_3"],
             "plugin_features":{
                 "FeatureKey1":"FeatureValue1",
                 "FeatureKey2":"FeatureValue2",
@@ -120,8 +97,7 @@ internal class GetPluginFeaturesResponseTests {
     fun `Get Response should throw exception if plugin_features is absent in json`() {
         val jsonString = """
         {
-            "config_type_list":["config_type_1", "config_type_2", "config_type_3"],
-            "allowed_config_feature_list":["config_feature_1", "config_feature_2", "config_feature_3"]
+            "config_type_list":["config_type_1", "config_type_2", "config_type_3"]
         }
         """.trimIndent()
         Assertions.assertThrows(IllegalArgumentException::class.java) {


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Since `allowed_config_features` is no longer being used this PR removes it from the Notifications Get Plugin Features API response
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
