### PR TITLE
Change default opensearch version to 2.0.0-alpha1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
     }
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Change default opensearch version to 2.0.0-alpha1-SNAPSHOT
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/1632
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
