### PR TITLE
Support sending email message via Notifications passthrough API

### DIFF
--- a/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
@@ -236,8 +236,9 @@ public class LegacyCustomWebhookMessage extends LegacyBaseMessage {
     @Override
     public void writeTo(StreamOutput streamOutput) throws IOException {
         super.writeTo(streamOutput);
-        // Making LegacyCustomWebhookMessage streamable is purely to support the new pass through API from ISM -> Notification plugin
-        // and it only supports LegacyCustomWebhookMessage when the url is already constructed by ISM.
+        // Making LegacyCustomWebhookMessage streamable is purely to support the new pass through API from Alerting/ISM -> Notification
+        // plugin
+        // and it only supports LegacyCustomWebhookMessage when the url is already constructed by Alerting/ISM.
         if (Strings.isNullOrEmpty(getUrl())) {
             throw new IllegalStateException("Cannot use LegacyCustomWebhookMessage across transport wire without defining full url.");
         }

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyDestinationType.java
@@ -11,5 +11,6 @@ package org.opensearch.commons.destination.message;
 public enum LegacyDestinationType {
     LEGACY_CHIME,
     LEGACY_SLACK,
-    LEGACY_CUSTOM_WEBHOOK
+    LEGACY_CUSTOM_WEBHOOK,
+    LEGACY_EMAIL
 }

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyEmailMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyEmailMessage.java
@@ -19,16 +19,18 @@ import org.opensearch.commons.notifications.model.MethodType;
  */
 public class LegacyEmailMessage extends LegacyBaseMessage {
 
-    private final String message;
+    private final String accountName;
     private final String host;
     private final int port;
     private final String method;
     private final String from;
     private final List<String> recipients;
     private final String subject;
+    private final String message;
 
     private LegacyEmailMessage(
         final String destinationName,
+        final String accountName,
         final String host,
         final Integer port,
         final String method,
@@ -41,6 +43,10 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
 
         if (Strings.isNullOrEmpty(message)) {
             throw new IllegalArgumentException("Message content is missing");
+        }
+
+        if (Strings.isNullOrEmpty(accountName)) {
+            throw new IllegalArgumentException("Account name should be provided");
         }
 
         if (Strings.isNullOrEmpty(host)) {
@@ -56,6 +62,7 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
         }
 
         this.message = message;
+        this.accountName = accountName;
         this.host = host;
         this.port = port == null ? 25 : port;
 
@@ -78,6 +85,7 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
     public LegacyEmailMessage(StreamInput streamInput) throws IOException {
         super(streamInput);
         this.message = super.getMessageContent();
+        this.accountName = streamInput.readString();
         this.host = streamInput.readString();
         this.port = streamInput.readInt();
         this.method = streamInput.readString();
@@ -92,6 +100,8 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
             + getChannelType()
             + ", DestinationName:"
             + destinationName
+            + ", AccountName:"
+            + accountName
             + ", From: "
             + from
             + ", Host: "
@@ -106,6 +116,7 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
 
     public static class Builder {
         private final String destinationName;
+        private String accountName;
         private String host;
         private Integer port;
         private String method;
@@ -116,6 +127,11 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
 
         public Builder(String destinationName) {
             this.destinationName = destinationName;
+        }
+
+        public LegacyEmailMessage.Builder withAccountName(String accountName) {
+            this.accountName = accountName;
+            return this;
         }
 
         public LegacyEmailMessage.Builder withHost(String host) {
@@ -156,6 +172,7 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
         public LegacyEmailMessage build() {
             return new LegacyEmailMessage(
                 this.destinationName,
+                this.accountName,
                 this.host,
                 this.port,
                 this.method,
@@ -165,6 +182,10 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
                 this.message
             );
         }
+    }
+
+    public String getAccountName() {
+        return accountName;
     }
 
     public String getHost() {
@@ -202,6 +223,7 @@ public class LegacyEmailMessage extends LegacyBaseMessage {
     @Override
     public void writeTo(StreamOutput streamOutput) throws IOException {
         super.writeTo(streamOutput);
+        streamOutput.writeString(accountName);
         streamOutput.writeString(host);
         streamOutput.writeInt(port);
         streamOutput.writeString(method);

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyEmailMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyEmailMessage.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.destination.message;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.commons.notifications.model.MethodType;
+
+/**
+ * This class holds the content of an CustomWebhook message
+ */
+public class LegacyEmailMessage extends LegacyBaseMessage {
+
+    private final String message;
+    private final String host;
+    private final int port;
+    private final String method;
+    private final String from;
+    private final List<String> recipients;
+    private final String subject;
+
+    private LegacyEmailMessage(
+        final String destinationName,
+        final String host,
+        final Integer port,
+        final String method,
+        final String from,
+        final List<String> recipients,
+        final String subject,
+        final String message
+    ) {
+        super(LegacyDestinationType.LEGACY_EMAIL, destinationName, message);
+
+        if (Strings.isNullOrEmpty(message)) {
+            throw new IllegalArgumentException("Message content is missing");
+        }
+
+        if (Strings.isNullOrEmpty(host)) {
+            throw new IllegalArgumentException("Host name should be provided");
+        }
+
+        if (Strings.isNullOrEmpty(from)) {
+            throw new IllegalArgumentException("From address should be provided");
+        }
+
+        if (recipients == null || recipients.isEmpty()) {
+            throw new IllegalArgumentException("List of recipients should be provided");
+        }
+
+        this.message = message;
+        this.host = host;
+        this.port = port == null ? 25 : port;
+
+        if (Strings.isNullOrEmpty(method)) {
+            // Default to "none"
+            this.method = "none";
+        } else if (!MethodType.NONE.toString().equals(method)
+            && !MethodType.SSL.toString().equals(method)
+            && !MethodType.START_TLS.toString().equals(method)) {
+            throw new IllegalArgumentException("Invalid method supplied. Only none, ssl and start_tls are allowed");
+        } else {
+            this.method = method;
+        }
+
+        this.from = from;
+        this.recipients = recipients;
+        this.subject = Strings.isNullOrEmpty(subject) ? destinationName : subject;
+    }
+
+    public LegacyEmailMessage(StreamInput streamInput) throws IOException {
+        super(streamInput);
+        this.message = super.getMessageContent();
+        this.host = streamInput.readString();
+        this.port = streamInput.readInt();
+        this.method = streamInput.readString();
+        this.from = streamInput.readString();
+        this.recipients = streamInput.readStringList();
+        this.subject = streamInput.readString();
+    }
+
+    @Override
+    public String toString() {
+        return "DestinationType: "
+            + getChannelType()
+            + ", DestinationName:"
+            + destinationName
+            + ", From: "
+            + from
+            + ", Host: "
+            + host
+            + ", Port: "
+            + port
+            + ", Method: "
+            + method
+            + ", Subject: <...>"
+            + ", Message: <...>";
+    }
+
+    public static class Builder {
+        private final String destinationName;
+        private String host;
+        private Integer port;
+        private String method;
+        private String from;
+        private List<String> recipients;
+        private String subject;
+        private String message;
+
+        public Builder(String destinationName) {
+            this.destinationName = destinationName;
+        }
+
+        public LegacyEmailMessage.Builder withHost(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withPort(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withMethod(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withRecipients(List<String> recipients) {
+            this.recipients = recipients;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withSubject(String subject) {
+            this.subject = subject;
+            return this;
+        }
+
+        public LegacyEmailMessage.Builder withMessage(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public LegacyEmailMessage build() {
+            return new LegacyEmailMessage(
+                this.destinationName,
+                this.host,
+                this.port,
+                this.method,
+                this.from,
+                this.recipients,
+                this.subject,
+                this.message
+            );
+        }
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public List<String> getRecipients() {
+        return recipients;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public URI getUri() {
+        return buildUri(null, null, host, port, null, null);
+    }
+
+    @Override
+    public void writeTo(StreamOutput streamOutput) throws IOException {
+        super.writeTo(streamOutput);
+        streamOutput.writeString(host);
+        streamOutput.writeInt(port);
+        streamOutput.writeString(method);
+        streamOutput.writeString(from);
+        streamOutput.writeStringCollection(recipients);
+        streamOutput.writeString(subject);
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/action/LegacyPublishNotificationRequest.kt
@@ -14,6 +14,7 @@ import org.opensearch.commons.destination.message.LegacyBaseMessage
 import org.opensearch.commons.destination.message.LegacyChimeMessage
 import org.opensearch.commons.destination.message.LegacyCustomWebhookMessage
 import org.opensearch.commons.destination.message.LegacyDestinationType
+import org.opensearch.commons.destination.message.LegacyEmailMessage
 import org.opensearch.commons.destination.message.LegacySlackMessage
 import java.io.IOException
 
@@ -50,6 +51,7 @@ class LegacyPublishNotificationRequest : ActionRequest {
             LegacyDestinationType.LEGACY_CHIME -> LegacyChimeMessage(input)
             LegacyDestinationType.LEGACY_CUSTOM_WEBHOOK -> LegacyCustomWebhookMessage(input)
             LegacyDestinationType.LEGACY_SLACK -> LegacySlackMessage(input)
+            LegacyDestinationType.LEGACY_EMAIL -> LegacyEmailMessage(input)
         }
     }
 

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
@@ -4,7 +4,6 @@
  */
 package org.opensearch.commons.notifications.model
 
-import org.opensearch.OpenSearchException
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
@@ -112,7 +111,7 @@ data class NotificationEvent(
         return try {
             XContentHelper.toXContent(this, XContentType.JSON, EMPTY_PARAMS, true).utf8ToString()
         } catch (e: IOException) {
-            throw OpenSearchException(e)
+            super.toString() + " threw " + e.toString()
         }
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
@@ -4,13 +4,17 @@
  */
 package org.opensearch.commons.notifications.model
 
+import org.opensearch.OpenSearchException
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.ToXContent.EMPTY_PARAMS
 import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentParser
 import org.opensearch.common.xcontent.XContentParserUtils
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.commons.notifications.NotificationConstants.EVENT_SOURCE_TAG
 import org.opensearch.commons.notifications.NotificationConstants.STATUS_LIST_TAG
 import org.opensearch.commons.utils.logger
@@ -101,5 +105,14 @@ data class NotificationEvent(
             .field(EVENT_SOURCE_TAG, eventSource)
             .field(STATUS_LIST_TAG, statusList)
             .endObject()
+    }
+
+    // Overriding toString so consuming plugins can log/output this from the  sendNotification response if needed
+    override fun toString(): String {
+        return try {
+            XContentHelper.toXContent(this, XContentType.JSON, EMPTY_PARAMS, true).utf8ToString()
+        } catch (e: IOException) {
+            throw OpenSearchException(e)
+        }
     }
 }

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyEmailMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyEmailMessageTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.destination.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class LegacyEmailMessageTest {
+
+    @Test
+    public void testBuildingLegacyEmailMessage() {
+        LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withHost("smtp.test.com")
+            .withPort(123)
+            .withMethod("none")
+            .withFrom("test@email.com")
+            .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+            .withSubject("Test Subject")
+            .withMessage("Hello world")
+            .build();
+
+        assertEquals("email", message.destinationName);
+        assertEquals(LegacyDestinationType.LEGACY_EMAIL, message.getChannelType());
+        assertEquals("smtp.test.com", message.getHost());
+        assertEquals(123, message.getPort());
+        assertEquals("none", message.getMethod());
+        assertEquals("test@email.com", message.getFrom());
+        assertEquals(Arrays.asList("test2@email.com", "test3@email.com"), message.getRecipients());
+        assertEquals("Test Subject", message.getSubject());
+        assertEquals("Hello world", message.getMessage());
+    }
+
+    @Test
+    public void testRoundTrippingLegacyEmailMessage() throws IOException {
+        LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withHost("smtp.test.com")
+            .withPort(123)
+            .withMethod("none")
+            .withFrom("test@email.com")
+            .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+            .withSubject("Test Subject")
+            .withMessage("Hello world")
+            .build();
+        BytesStreamOutput out = new BytesStreamOutput();
+        message.writeTo(out);
+
+        StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        LegacyEmailMessage newMessage = new LegacyEmailMessage(in);
+
+        assertEquals(newMessage.destinationName, message.destinationName);
+        assertEquals(newMessage.getChannelType(), message.getChannelType());
+        assertEquals(newMessage.getHost(), message.getHost());
+        assertEquals(newMessage.getPort(), message.getPort());
+        assertEquals(newMessage.getMethod(), message.getMethod());
+        assertEquals(newMessage.getFrom(), message.getFrom());
+        assertEquals(newMessage.getRecipients(), message.getRecipients());
+        assertEquals(newMessage.getSubject(), message.getSubject());
+        assertEquals(newMessage.getMessage(), message.getMessage());
+    }
+
+    @Test
+    public void testContentMissingMessage() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .build();
+            fail("Building legacy email message without message should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Message content is missing", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMissingDestinationName() {
+        try {
+            new LegacyEmailMessage.Builder(null)
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with null destination name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Channel name must be defined", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testUnsupportedMethods() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("unsupported")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with unsupported method should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid method supplied. Only none, ssl and start_tls are allowed", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testHostMissingOrEmpty() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with missing host should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Host name should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with empty host should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Host name should be provided", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testFromMissingOrEmpty() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with missing from should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("From address should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with empty from should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("From address should be provided", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testRecipientsMissingOrEmpty() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with missing recipients should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("List of recipients should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(List.of())
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with empty recipients should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("List of recipients should be provided", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSubjectDefaultsToDestinationNameWhenMissingOrEmpty() {
+        LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withHost("smtp.test.com")
+            .withPort(123)
+            .withMethod("none")
+            .withFrom("test@email.com")
+            .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+            .withMessage("Hello world")
+            .build();
+
+        assertEquals("email", message.getSubject());
+
+        message = new LegacyEmailMessage.Builder("email")
+            .withHost("smtp.test.com")
+            .withPort(123)
+            .withMethod("none")
+            .withFrom("test@email.com")
+            .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+            .withSubject("")
+            .withMessage("Hello world")
+            .build();
+
+        assertEquals("email", message.getSubject());
+    }
+}

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyEmailMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyEmailMessageTest.java
@@ -21,6 +21,7 @@ public class LegacyEmailMessageTest {
     @Test
     public void testBuildingLegacyEmailMessage() {
         LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withAccountName("test_email")
             .withHost("smtp.test.com")
             .withPort(123)
             .withMethod("none")
@@ -32,6 +33,7 @@ public class LegacyEmailMessageTest {
 
         assertEquals("email", message.destinationName);
         assertEquals(LegacyDestinationType.LEGACY_EMAIL, message.getChannelType());
+        assertEquals("test_email", message.getAccountName());
         assertEquals("smtp.test.com", message.getHost());
         assertEquals(123, message.getPort());
         assertEquals("none", message.getMethod());
@@ -44,6 +46,7 @@ public class LegacyEmailMessageTest {
     @Test
     public void testRoundTrippingLegacyEmailMessage() throws IOException {
         LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withAccountName("test_email")
             .withHost("smtp.test.com")
             .withPort(123)
             .withMethod("none")
@@ -60,6 +63,7 @@ public class LegacyEmailMessageTest {
 
         assertEquals(newMessage.destinationName, message.destinationName);
         assertEquals(newMessage.getChannelType(), message.getChannelType());
+        assertEquals(newMessage.getAccountName(), message.getAccountName());
         assertEquals(newMessage.getHost(), message.getHost());
         assertEquals(newMessage.getPort(), message.getPort());
         assertEquals(newMessage.getMethod(), message.getMethod());
@@ -73,6 +77,7 @@ public class LegacyEmailMessageTest {
     public void testContentMissingMessage() {
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -90,6 +95,7 @@ public class LegacyEmailMessageTest {
     public void testMissingDestinationName() {
         try {
             new LegacyEmailMessage.Builder(null)
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -108,6 +114,7 @@ public class LegacyEmailMessageTest {
     public void testUnsupportedMethods() {
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("unsupported")
@@ -123,9 +130,44 @@ public class LegacyEmailMessageTest {
     }
 
     @Test
+    public void testAccountNameMissingOrEmpty() {
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with missing account name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Account name should be provided", e.getMessage());
+        }
+
+        try {
+            new LegacyEmailMessage.Builder("email")
+                .withAccountName("")
+                .withHost("smtp.test.com")
+                .withPort(123)
+                .withMethod("none")
+                .withFrom("test@email.com")
+                .withRecipients(Arrays.asList("test2@email.com", "test3@email.com"))
+                .withSubject("Test Subject")
+                .withMessage("Hello world")
+                .build();
+            fail("Building legacy email message with empty account name should fail");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Account name should be provided", e.getMessage());
+        }
+    }
+
+    @Test
     public void testHostMissingOrEmpty() {
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withPort(123)
                 .withMethod("none")
                 .withFrom("test@email.com")
@@ -140,6 +182,7 @@ public class LegacyEmailMessageTest {
 
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("")
                 .withPort(123)
                 .withMethod("none")
@@ -158,6 +201,7 @@ public class LegacyEmailMessageTest {
     public void testFromMissingOrEmpty() {
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -172,6 +216,7 @@ public class LegacyEmailMessageTest {
 
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -190,6 +235,7 @@ public class LegacyEmailMessageTest {
     public void testRecipientsMissingOrEmpty() {
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -204,6 +250,7 @@ public class LegacyEmailMessageTest {
 
         try {
             new LegacyEmailMessage.Builder("email")
+                .withAccountName("test_email")
                 .withHost("smtp.test.com")
                 .withPort(123)
                 .withMethod("none")
@@ -221,6 +268,7 @@ public class LegacyEmailMessageTest {
     @Test
     public void testSubjectDefaultsToDestinationNameWhenMissingOrEmpty() {
         LegacyEmailMessage message = new LegacyEmailMessage.Builder("email")
+            .withAccountName("test_email")
             .withHost("smtp.test.com")
             .withPort(123)
             .withMethod("none")
@@ -232,6 +280,7 @@ public class LegacyEmailMessageTest {
         assertEquals("email", message.getSubject());
 
         message = new LegacyEmailMessage.Builder("email")
+            .withAccountName("test_email")
             .withHost("smtp.test.com")
             .withPort(123)
             .withMethod("none")


### PR DESCRIPTION
### Description
The Notifications passthrough API is used for sending legacy messages for consumers of the old notification subproject in Alerting. Alerting has support for Email Destinations that need to use the passthrough API as a fallback mechanism for Destinations that have not migrated.

This PR adds support for email via passthrough.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
