### PR TITLE
Remove JDK 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         java: 
           - 11
-          - 14
           - 17
 
     name: Build and Test


### PR DESCRIPTION
Signed-off-by: Saurabh Singh <sisurab@amazon.com>

### Description
In OpenSearch 2.0 we are building the complete distribution and every component with JDK 11, and testing and bundling JDK 17. Support for JDK 14, 15 and other non-LTS versions can be dropped. Remove building and testing with these JDKs from CI.

See https://opensearch.org/blog/technical-post/2022/03/opensearch-java-runtime/ for more information.
 
### Issues Resolved
[[List any issues this PR will resolve]](https://github.com/opensearch-project/common-utils/issues/147)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
