### PR TITLE
[Backport 2.0] Removing RC1 as the qualifier from Common Utils (#168)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
     }
 


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>
Signed-off-by: Saurabh Singh <sisurab@amazon.com>

### Description
[[#165]](https://github.com/opensearch-project/common-utils/issues/165)
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [x] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
