### PR TITLE
Changing the Return Type of SendNotificationsResponse

### DIFF
--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -190,7 +190,7 @@ internal class NotificationsPluginInterfaceTests {
             deliveryStatus = DeliveryStatus("404", "invalid recipient")
         )
 
-        val sampleEvent = NotificationEvent(notificationInfo, listOf(sampleStatus))
+        val sampleEvent = listOf(NotificationEvent(notificationInfo, listOf(sampleStatus)))
 
         val response = SendNotificationResponse(sampleEvent)
         val listener: ActionListener<SendNotificationResponse> =

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationResponseTests.kt
@@ -65,7 +65,7 @@ internal class SendNotificationResponseTests {
 
     @Test
     fun `Create response should safely ignore extra field in json object`() {
-        val sampleEvent = getSampleEvent()
+        val sampleEvent = getSampleEvents()
         val jsonString = """
         {
             "event_id":"$sampleEvent",
@@ -92,5 +92,36 @@ internal class SendNotificationResponseTests {
         )
 
         return NotificationEvent(sampleEventSource, listOf(sampleStatus))
+    }
+
+    private fun getSampleEvents(): List<NotificationEvent> {
+        val sampleEventSourceOne = EventSource(
+            "title",
+            "reference_id",
+            severity = SeverityType.INFO
+        )
+        val sampleStatusOne = EventStatus(
+            "config_id",
+            "name",
+            ConfigType.SLACK,
+            deliveryStatus = DeliveryStatus("404", "invalid recipient")
+        )
+
+        val sampleEventSourceTwo = EventSource(
+            "title",
+            "reference_id",
+            severity = SeverityType.INFO
+        )
+        val sampleStatusTwo = EventStatus(
+            "config_id",
+            "name",
+            ConfigType.SLACK,
+            deliveryStatus = DeliveryStatus("404", "invalid recipient")
+        )
+
+        return listOf(
+            NotificationEvent(sampleEventSourceOne, listOf(sampleStatusOne)),
+            NotificationEvent(sampleEventSourceTwo, listOf(sampleStatusTwo))
+        )
     }
 }


### PR DESCRIPTION
Signed-off-by: Aditya Jindal <aditjind@amazon.com>

### Description
This adds a List of NotificationEvents to the SendMessage API Response. SendMessage APIs response reflects the status of the notifications which have been sent.  
 
### Issues Resolved
https://github.com/opensearch-project/notifications/issues/441
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
