### PR TITLE
Update Notifications BaseModel to extend ToXContentObject instead of ToXContent

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/BaseModel.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/BaseModel.kt
@@ -5,9 +5,9 @@
 package org.opensearch.commons.notifications.model
 
 import org.opensearch.common.io.stream.Writeable
-import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.ToXContentObject
 
 /**
  * interface for representing objects.
  */
-interface BaseModel : Writeable, ToXContent
+interface BaseModel : Writeable, ToXContentObject

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/NotificationEvent.kt
@@ -111,6 +111,7 @@ data class NotificationEvent(
         return try {
             XContentHelper.toXContent(this, XContentType.JSON, EMPTY_PARAMS, true).utf8ToString()
         } catch (e: IOException) {
+            log.debug("Failed to convert NotificationEvent to string", e)
             super.toString() + " threw " + e.toString()
         }
     }


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
By default `ToXContent` has `isFragment` set to `true`. When calling `XContentHelper.toXContent()` for a fragment, it will wrap the contents in another object and expect a named object afterwards, this results in `IOException`s when not satisfied (like in NotificationEvent when converting to a string). 

Since all of the children of `BaseModel` are already wrapped in objects, they should not be treated as fragments. This PR updates BaseModel to be a `ToXContentObject` instead to reflect this.

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
