### PR TITLE
Model2 Approach to a Unified Common-Utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,22 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.2.0")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        plugin_no_snapshot = opensearch_build
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+            plugin_no_snapshot += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
+        }
+        opensearch_no_snapshot = opensearch_version.replace("-SNAPSHOT", "")
         kotlin_version = System.getProperty("kotlin.version", "1.6.10")
+
     }
 
     repositories {
@@ -20,17 +32,18 @@ buildscript {
     }
 
     dependencies {
+        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "${opensearch_group}.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.20.0-RC1"
+        //classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.20.0-RC1"
     }
 }
 
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id "com.diffplug.gradle.spotless" version "3.26.1"
+    // id "com.diffplug.gradle.spotless" version "3.26.1"
 }
 
 repositories {
@@ -59,7 +72,7 @@ apply plugin: 'jacoco'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
 apply plugin: 'com.github.johnrengelman.shadow'
-apply plugin: 'io.gitlab.arturbosch.detekt'
+//apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
 apply plugin: 'opensearch.repositories'
@@ -94,7 +107,7 @@ test {
     }
 }
 
-spotless {
+/*spotless {
     java {
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
@@ -102,11 +115,11 @@ spotless {
 
         eclipse().configFile rootProject.file('.eclipseformat.xml')
     }
-}
-detekt {
+}*/
+/*detekt {
     config = files("detekt.yml")
     buildUponDefaultConfig = true
-}
+}*/
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ configurations {
 }
 
 dependencies {
+    implementation group: 'org.json', name: 'json', version: '20220320'
     compileOnly "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"

--- a/src/main/java/org/opensearch/commons/model2/AbstractModel.java
+++ b/src/main/java/org/opensearch/commons/model2/AbstractModel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2;
+
+public class AbstractModel implements ToXContentModel {
+
+    public AbstractModel() {
+        // for serialization
+    }
+
+    @Override
+    public int hashCode() {
+        return ModelSerializer.getHashCode(this);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return ModelSerializer.areEquals(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return ModelSerializer.getString(this);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/ModelSerializer.java
+++ b/src/main/java/org/opensearch/commons/model2/ModelSerializer.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.model2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.io.stream.Writeable;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ModelSerializer {
+
+    private static final Logger LOG = LogManager.getLogger(ModelSerializer.class);
+
+    private ModelSerializer() {
+        // do nothing
+    }
+
+    public static class ReaderWriter<T> implements Writeable.Reader<T>, Writeable.Writer<T> {
+
+        private final Class<T> modelClass;
+
+        public ReaderWriter(final Class<T> modelClass) {
+            this.modelClass = modelClass;
+        }
+
+        @Override
+        public T read(final StreamInput input) throws IOException {
+            return ModelSerializer.read(input, this.modelClass);
+        }
+
+        @Override
+        public void write(final StreamOutput output, final T t) throws IOException {
+            ModelSerializer.write(output, t);
+        }
+    }
+
+    public static <T> XContentBuilder write(final XContentBuilder builder, final T model) throws IOException {
+        builder.startObject();
+        try {
+            for (final Field field : ModelSerializer.getSortedFields(model.getClass())) {
+                builder.field(field.getName(), field.get(model));
+            }
+        } catch (IllegalAccessException e) {
+            throw new IOException(e);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static <T> T read(final XContentParser parser, final Class modelClass) throws IOException {
+        try {
+            final T model = (T) modelClass.getConstructor().newInstance();
+            for (final Field field : ModelSerializer.getSortedFields(model.getClass())) {
+                final String fieldName = parser.currentName();
+                assert field.getName().equals(fieldName);
+                parser.nextToken();
+                if (checkType(field, Boolean.class))
+                    field.set(model, parser.booleanValue());
+                else if (checkType(field, String.class))
+                    field.set(model, parser.text());
+                else if (checkType(field, Long.class))
+                    field.set(model, parser.longValue());
+                else if (checkType(field, Integer.class))
+                    field.set(model, parser.intValue());
+                else if (checkType(field, TimeValue.class))
+                    field.set(model, new TimeValue(parser.longValue()));
+                else if (checkType(field, ChronoUnit.class))
+                    field.set(model, ChronoUnit.valueOf(parser.text()));
+                else if (checkType(field, List.class))
+                    field.set(model, parser.list());
+                else if (checkType(field, ToXContentObject.class))
+                    field.set(model, parser.objectBytes());
+                else
+                    throw new IllegalArgumentException(String.format(Locale.getDefault(), "Unsupported field type %s in model %s", field.getType().getName(), model.getClass().getSimpleName()));
+            }
+            return model;
+        } catch (final Exception e) {
+            if (e instanceof IOException)
+                throw (IOException) e;
+            else
+                throw new IOException(e);
+        }
+    }
+
+    public static <T> void write(final StreamOutput output, final T model) throws IOException {
+        try {
+            // output.writeString(model.getClass().getName());
+            for (final Field field : ModelSerializer.getSortedFields(model.getClass())) {
+                if (null == field.get(model))
+                    output.writeBoolean(false);
+                else {
+                    output.writeBoolean(true);
+                    if (checkType(field, boolean.class))
+                        output.writeBoolean(field.getBoolean(model));
+                    else if (checkType(field, String.class))
+                        output.writeString((String) field.get(model));
+                    else if (checkType(field, long.class))
+                        output.writeLong(field.getLong(model));
+                    else if (checkType(field, int.class))
+                        output.writeInt(field.getInt(model));
+                    else if (checkType(field, TimeValue.class))
+                        output.writeTimeValue((TimeValue) field.get(model));
+                    else if (checkType(field, ChronoUnit.class))
+                        output.writeEnum((ChronoUnit) field.get(model));
+                    else if (checkType(field, List.class, String.class))
+                        output.writeStringCollection((List<String>) field.get(model));
+                    else if (checkType(field, List.class)) {
+                        List list = (List) field.get(model);
+                        output.writeInt(list.size());
+                        for (final Object obj : list) {
+                            ModelSerializer.write(output, obj);
+                        }
+                    } else if (checkType(field, ToXContentObject.class))
+                        ModelSerializer.write(output, field.get(model));
+                    else
+                        throw new IllegalArgumentException(String.format(Locale.getDefault(), "Unsupported field type %s in model %s", field.getType().getName(), model.getClass().getSimpleName()));
+                }
+            }
+        } catch (IllegalAccessException e) {
+            throw new IOException(e);
+        }
+    }
+
+
+    public static <T> T read(final StreamInput input, final Class<T> modelClass) throws IOException {
+        try {
+            //final Class<T> modelClassCalc = (Class<T>) Class.forName(input.readString());
+            final T model = modelClass.getConstructor().newInstance();
+            for (final Field field : ModelSerializer.getSortedFields(modelClass)) {
+                final boolean exists = input.readBoolean();
+                if (exists) {
+                    if (checkType(field, boolean.class))
+                        field.set(model, input.readBoolean());
+                    else if (checkType(field, String.class))
+                        field.set(model, input.readString());
+                    else if (checkType(field, long.class))
+                        field.set(model, input.readLong());
+                    else if (checkType(field, int.class))
+                        field.set(model, input.readInt());
+                    else if (checkType(field, TimeValue.class))
+                        field.set(model, input.readTimeValue());
+                    else if (checkType(field, ChronoUnit.class))
+                        field.set(model, input.readEnum(ChronoUnit.class));
+                    else if (checkType(field, List.class, String.class))
+                        field.set(model, input.readStringList());
+                    else if (checkType(field, List.class)) {
+                        final int size = input.readInt();
+                        final List list = new ArrayList();
+                        for (int i = 0; i < size; i++) {
+                            list.add(ModelSerializer.read(input, getListGeneric(field)));
+                        }
+                        field.set(model, list);
+                    } else if (checkType(field, ToXContentObject.class))
+                        field.set(model, ModelSerializer.read(input, field.getType()));
+                    else
+                        throw new IllegalArgumentException(String.format(Locale.getDefault(), "Unsupported field type %s in model %s", field.getType().getName(), model.getClass().getSimpleName()));
+                }
+            }
+            return model;
+        } catch (final Exception e) {
+            if (e instanceof IOException)
+                throw (IOException) e;
+            else
+                throw new IOException(e);
+        }
+    }
+
+    public static int getHashCode(final Object object) {
+        return ModelSerializer.getSortedFields(object.getClass())
+                .stream()
+                .map(field -> {
+                    try {
+                        return Objects.hashCode(field.get(object));
+                    } catch (final Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .reduce((a, b) -> a ^ b).orElseThrow();
+    }
+
+    public static String getString(final Object object) {
+        final StringBuilder builder = new StringBuilder(object.getClass().getSimpleName()).append("[");
+        ModelSerializer.getSortedFields(object.getClass())
+                .forEach(field -> {
+                    try {
+                        builder.append(field.getName()).append("=").append(field.get(object)).append(",");
+                    } catch (final Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+        builder.deleteCharAt(builder.length() - 1);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public static boolean areEquals(final Object a, final Object b) {
+        if (!a.getClass().equals(b.getClass()))
+            return false;
+        return ModelSerializer.getSortedFields(a.getClass())
+                .stream()
+                .allMatch(field -> {
+                    try {
+                        return Objects.equals(field.get(a), field.get(b));
+                    } catch (final NullPointerException e1) {
+                        return false;
+                    } catch (final Exception e2) {
+                        throw new RuntimeException(e2);
+                    }
+                });
+    }
+
+    public static List<Field> getSortedFields(final Class<?> modelClass) {
+        return Arrays.stream(modelClass.getFields())
+                .filter(field -> Modifier.isPublic(field.getModifiers()))
+                .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                .sorted(Comparator.comparing(Field::getName))
+                .collect(Collectors.toList());
+    }
+
+    public static boolean checkType(final Field check, final Class<?> against) {
+        return against.isAssignableFrom(check.getType());
+    }
+
+    public static <T> Class<T> getListGeneric(final Field field) {
+        if (!(field.getGenericType() instanceof ParameterizedType))
+            throw new IllegalArgumentException();
+        try {
+            final ParameterizedType paramType = (ParameterizedType) field.getGenericType();
+            return (Class<T>) Class.forName(paramType.getActualTypeArguments()[0].getTypeName());
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> boolean checkType(final Field check, final Class<? extends Collection> collection,
+                                        final Class<T> elements) {
+        try {
+            if (!(check.getGenericType() instanceof ParameterizedType))
+                return false;
+            final ParameterizedType paramType = (ParameterizedType) check.getGenericType();
+            return collection.isAssignableFrom(Class.forName(paramType.getRawType().getTypeName())) &&
+                    elements.isAssignableFrom(Class.forName(paramType.getActualTypeArguments()[0].getTypeName()));
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/ModelSerializer.java
+++ b/src/main/java/org/opensearch/commons/model2/ModelSerializer.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -81,6 +82,8 @@ public class ModelSerializer {
                     field.set(model, new TimeValue(parser.longValue()));
                 else if (checkType(field, ChronoUnit.class))
                     field.set(model, ChronoUnit.valueOf(parser.text()));
+                else if (checkType(field, ZoneId.class))
+                    field.set(model, ZoneId.of(parser.text()));
                 else if (checkType(field, List.class))
                     field.set(model, parser.list());
                 else if (checkType(field, ToXContentObject.class))
@@ -117,6 +120,8 @@ public class ModelSerializer {
                         output.writeTimeValue((TimeValue) field.get(model));
                     else if (checkType(field, ChronoUnit.class))
                         output.writeEnum((ChronoUnit) field.get(model));
+                    else if (checkType(field, ZoneId.class))
+                        output.writeString(field.get(model).toString());
                     else if (checkType(field, List.class, String.class))
                         output.writeStringCollection((List<String>) field.get(model));
                     else if (checkType(field, List.class)) {
@@ -156,6 +161,8 @@ public class ModelSerializer {
                         field.set(model, input.readTimeValue());
                     else if (checkType(field, ChronoUnit.class))
                         field.set(model, input.readEnum(ChronoUnit.class));
+                    else if (checkType(field, ZoneId.class))
+                        field.set(model, ZoneId.of(input.readString()));
                     else if (checkType(field, List.class, String.class))
                         field.set(model, input.readStringList());
                     else if (checkType(field, List.class)) {

--- a/src/main/java/org/opensearch/commons/model2/ToXContentModel.java
+++ b/src/main/java/org/opensearch/commons/model2/ToXContentModel.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2;
+
+import org.opensearch.common.ParseField;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Locale;
+
+public interface ToXContentModel extends ToXContentObject {
+
+    static NamedXContentRegistry.Entry createRegistryEntry(final Class<? extends ToXContentModel> modelClass) {
+        return new NamedXContentRegistry.Entry(modelClass, new ParseField(modelClass.getSimpleName().toLowerCase(Locale.getDefault())), parser -> ModelSerializer.read(parser, modelClass));
+    }
+
+    @Override
+    default XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        return ModelSerializer.write(builder, this);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorAction.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorAction.java
@@ -4,10 +4,16 @@ import org.opensearch.action.ActionType;
 
 public class ExecuteMonitorAction extends ActionType<ExecuteMonitorResponse> {
 
-    public static final String ALERTING_NAME = "cluster:admin/opendistro/security_analytics/monitor/execute";
-    public static final ExecuteMonitorAction ALERTING_INSTANCE = new ExecuteMonitorAction(ALERTING_NAME);
+    public static final String ACTION_TEMPLATE = "cluster:admin/opendistro/${plugin}/monitor/${method}";
+    public static final ExecuteMonitorAction ALERTING_BRIDGE_INSTANCE = new ExecuteMonitorAction(ACTION_TEMPLATE.replace("${plugin}","alerting").replace("${method}","execute2"));
+    public static final ExecuteMonitorAction SAP_INSTANCE = new ExecuteMonitorAction(ACTION_TEMPLATE.replace("${plugin}","security").replace("${method}","execute"));
 
     private ExecuteMonitorAction(final String name) {
         super(name, ExecuteMonitorResponse::new);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + "[" + this.name() + "]";
     }
 }

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorAction.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorAction.java
@@ -1,0 +1,13 @@
+package org.opensearch.commons.model2.action;
+
+import org.opensearch.action.ActionType;
+
+public class ExecuteMonitorAction extends ActionType<ExecuteMonitorResponse> {
+
+    public static final String ALERTING_NAME = "cluster:admin/opendistro/security_analytics/monitor/execute";
+    public static final ExecuteMonitorAction ALERTING_INSTANCE = new ExecuteMonitorAction(ALERTING_NAME);
+
+    private ExecuteMonitorAction(final String name) {
+        super(name, ExecuteMonitorResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorRequest.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorRequest.java
@@ -1,0 +1,33 @@
+package org.opensearch.commons.model2.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.commons.model2.ModelSerializer;
+import org.opensearch.commons.model2.model.Monitor;
+
+import java.io.IOException;
+
+public class ExecuteMonitorRequest extends ActionRequest {
+
+    private static final Logger LOG = LogManager.getLogger(ExecuteMonitorRequest.class);
+
+    Monitor monitor;
+
+    public ExecuteMonitorRequest(final Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        ModelSerializer.write(out, this.monitor);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorRequest.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorRequest.java
@@ -14,7 +14,7 @@ public class ExecuteMonitorRequest extends ActionRequest {
 
     private static final Logger LOG = LogManager.getLogger(ExecuteMonitorRequest.class);
 
-    Monitor monitor;
+    public Monitor monitor;
 
     public ExecuteMonitorRequest(final Monitor monitor) {
         this.monitor = monitor;

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorResponse.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorResponse.java
@@ -1,0 +1,45 @@
+package org.opensearch.commons.model2.action;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.commons.model2.ModelSerializer;
+import org.opensearch.commons.model2.model.Monitor;
+
+import java.io.IOException;
+
+public class ExecuteMonitorResponse extends ActionResponse implements ToXContentObject {
+
+    private static final Logger LOG = LogManager.getLogger(ExecuteMonitorResponse.class);
+
+    private final Monitor monitor;
+
+    public ExecuteMonitorResponse(final Monitor monitor) {
+        this.monitor = monitor;
+    }
+
+    public ExecuteMonitorResponse(final StreamInput input) throws IOException {
+        this.monitor = ModelSerializer.read(input, Monitor.class);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput output) throws IOException {
+        ModelSerializer.write(output, this.monitor);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, ToXContent.Params params) throws IOException {
+        return ModelSerializer.write(xContentBuilder, this.monitor);
+        // return xContentBuilder.startObject().field(Tokens.MONITOR_ID, this.monitorId).endObject();
+    }
+
+    @Override
+    public boolean isFragment() {
+        return false;
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorResponse.java
+++ b/src/main/java/org/opensearch/commons/model2/action/ExecuteMonitorResponse.java
@@ -9,7 +9,6 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.commons.model2.ModelSerializer;
-import org.opensearch.commons.model2.model.Monitor;
 
 import java.io.IOException;
 
@@ -17,25 +16,24 @@ public class ExecuteMonitorResponse extends ActionResponse implements ToXContent
 
     private static final Logger LOG = LogManager.getLogger(ExecuteMonitorResponse.class);
 
-    private final Monitor monitor;
+    public String monitorName;
 
-    public ExecuteMonitorResponse(final Monitor monitor) {
-        this.monitor = monitor;
+    public ExecuteMonitorResponse(final String monitorName) {
+        this.monitorName = monitorName;
     }
 
     public ExecuteMonitorResponse(final StreamInput input) throws IOException {
-        this.monitor = ModelSerializer.read(input, Monitor.class);
+        this.monitorName = input.readString();
     }
 
     @Override
     public void writeTo(final StreamOutput output) throws IOException {
-        ModelSerializer.write(output, this.monitor);
+        ModelSerializer.write(output, this.monitorName);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, ToXContent.Params params) throws IOException {
-        return ModelSerializer.write(xContentBuilder, this.monitor);
-        // return xContentBuilder.startObject().field(Tokens.MONITOR_ID, this.monitorId).endObject();
+        return ModelSerializer.write(xContentBuilder, this.monitorName);
     }
 
     @Override

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
@@ -9,8 +9,8 @@ import org.opensearch.action.ActionType;
 
 public class IndexMonitorAction extends ActionType<IndexMonitorResponse> {
 
-    public static final String ALERTING_NAME = "cluster:admin/opendistro/security_analytics/monitor/index";
-    public static final IndexMonitorAction ALERTING_INSTANCE = new IndexMonitorAction(ALERTING_NAME);
+    public static final String SAP_ALERTING_BRIDGE_NAME = "cluster:admin/opendistro/alerting/monitor/write2";
+    public static final IndexMonitorAction SAP_ALERTING_BRIDGE_INSTANCE = new IndexMonitorAction(SAP_ALERTING_BRIDGE_NAME);
 
     private IndexMonitorAction(final String name) {
         super(name, IndexMonitorResponse::new);

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.action;
+
+import org.opensearch.action.ActionType;
+
+public class IndexMonitorAction extends ActionType<IndexMonitorResponse> {
+
+    public static final String ALERTING_NAME = "cluster:admin/opendistro/security_analytics/monitor/index";
+    public static final IndexMonitorAction ALERTING_INSTANCE = new IndexMonitorAction(ALERTING_NAME);
+
+    private IndexMonitorAction(final String name) {
+        super(name, IndexMonitorResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorAction.java
@@ -9,10 +9,16 @@ import org.opensearch.action.ActionType;
 
 public class IndexMonitorAction extends ActionType<IndexMonitorResponse> {
 
-    public static final String SAP_ALERTING_BRIDGE_NAME = "cluster:admin/opendistro/alerting/monitor/write2";
-    public static final IndexMonitorAction SAP_ALERTING_BRIDGE_INSTANCE = new IndexMonitorAction(SAP_ALERTING_BRIDGE_NAME);
+    public static final String ACTION_TEMPLATE = "cluster:admin/opendistro/${plugin}/monitor/${method}";
+    public static final IndexMonitorAction ALERTING_BRIDGE_INSTANCE = new IndexMonitorAction(ACTION_TEMPLATE.replace("${plugin}","alerting").replace("${method}","write2"));
+    public static final IndexMonitorAction SAP_INSTANCE = new IndexMonitorAction(ACTION_TEMPLATE.replace("${plugin}","security").replace("${method}","write"));
 
     private IndexMonitorAction(final String name) {
         super(name, IndexMonitorResponse::new);
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + "[" + this.name() + "]";
     }
 }

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorRequest.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.model2.action;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.commons.model2.ModelSerializer;
+import org.opensearch.commons.model2.model.Monitor;
+import org.opensearch.rest.RestRequest;
+
+import java.io.IOException;
+
+public class IndexMonitorRequest extends ActionRequest {
+    public final String monitorId;
+    public final Long seqNo;
+    public final Long primaryTerm;
+    public final WriteRequest.RefreshPolicy refreshPolicy;
+    public final RestRequest.Method method;
+    public final Monitor monitor;
+
+    public IndexMonitorRequest(final String monitorId, final Long seqNo, final Long primaryTerm, final WriteRequest.RefreshPolicy refreshPolicy, final RestRequest.Method method, final Monitor monitor) {
+        this.monitorId = monitorId;
+        this.seqNo = seqNo;
+        this.primaryTerm = primaryTerm;
+        this.refreshPolicy = refreshPolicy;
+        this.method = method;
+        this.monitor = monitor;
+    }
+
+    public IndexMonitorRequest(final StreamInput input) throws IOException {
+        this(input.readString(), input.readLong(), input.readLong(), WriteRequest.RefreshPolicy.readFrom(input), input.readEnum(RestRequest.Method.class), ModelSerializer.read(input, Monitor.class));
+
+    }
+
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public void writeTo(StreamOutput output) throws IOException {
+        output.writeString(this.monitorId);
+        output.writeLong(this.seqNo);
+        output.writeLong(this.primaryTerm);
+        this.refreshPolicy.writeTo(output);
+        output.writeEnum(this.method);
+        ModelSerializer.write(output, this.monitor);
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorResponse.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorResponse.java
@@ -11,9 +11,9 @@ import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.ToXContentObject;
 import org.opensearch.common.xcontent.XContentBuilder;
 import org.opensearch.commons.model2.ModelSerializer;
+import org.opensearch.commons.model2.model.Monitor;
 import org.opensearch.rest.RestStatus;
 
-import javax.management.monitor.Monitor;
 import java.io.IOException;
 
 public class IndexMonitorResponse extends ActionResponse implements ToXContentObject {

--- a/src/main/java/org/opensearch/commons/model2/action/IndexMonitorResponse.java
+++ b/src/main/java/org/opensearch/commons/model2/action/IndexMonitorResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.model2.action;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.ToXContent;
+import org.opensearch.common.xcontent.ToXContentObject;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.commons.model2.ModelSerializer;
+import org.opensearch.rest.RestStatus;
+
+import javax.management.monitor.Monitor;
+import java.io.IOException;
+
+public class IndexMonitorResponse extends ActionResponse implements ToXContentObject {
+
+    public static final String _ID = "_id";
+    public static final String _VERSION = "_version";
+    public static final String _SEQ_NO = "_seq_no";
+    public static final String IF_SEQ_NO = "if_seq_no";
+    public static final String _PRIMARY_TERM = "_primary_term";
+    public static final String IF_PRIMARY_TERM = "if_primary_term";
+    public static final String REFRESH = "refresh";
+
+    public String id;
+    public Long version;
+    public Long seqNo;
+    public Long primaryTerm;
+    public RestStatus status;
+    public Monitor monitor;
+
+    public IndexMonitorResponse(final String id, final Long version, final Long seqNo, final Long primaryTerm, final RestStatus status, final Monitor monitor) {
+        this.id = id;
+        this.version = version;
+        this.seqNo = seqNo;
+        this.primaryTerm = primaryTerm;
+        this.status = status;
+        this.monitor = monitor;
+    }
+
+
+    public IndexMonitorResponse(final StreamInput input) throws IOException {
+        this(input.readString(), input.readLong(), input.readLong(), input.readLong(), input.readEnum(RestStatus.class), ModelSerializer.read(input, Monitor.class));
+    }
+
+    @Override
+    public void writeTo(final StreamOutput output) throws IOException {
+        output.writeString(this.id);
+        output.writeLong(this.version);
+        output.writeLong(this.seqNo);
+        output.writeLong(this.primaryTerm);
+        output.writeEnum(this.status);
+        ModelSerializer.write(output, this.monitor);
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, ToXContent.Params params) throws IOException {
+        return builder.startObject()
+                .field(_ID, this.id)
+                .field(_VERSION, this.version)
+                .field(_SEQ_NO, this.seqNo)
+                .field(_PRIMARY_TERM, this.primaryTerm)
+                .field("monitor", this.monitor)
+                .endObject();
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Action.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Action.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+import java.util.List;
+
+public class Action extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Action.class);
+
+    public String id;
+    public String name;
+    public String destination_id;
+    public Script subject_template;
+    public Script message_template;
+    public boolean throttled_enabled;
+    public Throttle throttle;
+    public ExecutionPolicy action_execution_policy;
+
+    //val throttleEnabled: Boolean,
+    // val throttle: Throttle?,
+    //val id: String = UUIDs.base64UUID(),
+    //val actionExecutionPolicy: ActionExecutionPolicy? = null
+    public Action() {
+        // for serialization
+    }
+
+    public Action(final String id, final String name, final String destination_id, final Script subject_template, final Script message_template, final boolean throttled_enabled, final Throttle throttle, final ExecutionPolicy action_execution_policy) {
+        this.id = id;
+        this.name = name;
+        this.destination_id = destination_id;
+        this.subject_template = subject_template;
+        this.message_template = message_template;
+        this.throttled_enabled = throttled_enabled;
+        this.throttle = throttle;
+        this.action_execution_policy = action_execution_policy;
+    }
+
+    public static class ExecutionPolicy extends AbstractModel {
+
+        public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(ExecutionPolicy.class);
+
+        public ExecutionScope action_execution_scope;
+
+        public ExecutionPolicy() {
+            // for serialization
+        }
+
+        public ExecutionPolicy(final ExecutionScope action_execution_scope) {
+            this.action_execution_scope = action_execution_scope;
+        }
+    }
+
+    public static class ExecutionScope extends AbstractModel {
+
+        public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(ExecutionScope.class);
+
+        public PerScope per_alert;
+
+        public ExecutionScope() {
+            // for serialization
+        }
+
+        public ExecutionScope(final PerScope per_alert) {
+            this.per_alert = per_alert;
+        }
+
+        public static class PerScope extends AbstractModel {
+
+            public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(PerScope.class);
+
+            //public enum AlertCategory {DEDUPED, NEW, COMPLETE}
+
+            public List<String> actionable_alerts;
+
+            public PerScope() {
+                // for serialization
+            }
+
+            public PerScope(final List<String> actionable_alerts) {
+                this.actionable_alerts = actionable_alerts;
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Input.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Input.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+import java.util.List;
+
+public class Input extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Input.class);
+
+    public String description;
+    public List<String> indices;
+    public List<Query> queries;
+
+    public Input() {
+        // for serialization
+    }
+
+    public Input(final String description, final List<String> indices, final List<Query> queries) {
+        this.description = description;
+        this.indices = indices;
+        this.queries = queries;
+    }
+}
+

--- a/src/main/java/org/opensearch/commons/model2/model/Monitor.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Monitor.java
@@ -18,6 +18,7 @@ public class Monitor extends AbstractModel {
     public String id;
     public String monitor_type;
     public long version;
+    public Schedule schedule;
     public String name;
     public long interval;
     public String unit;
@@ -27,10 +28,11 @@ public class Monitor extends AbstractModel {
         // for serialization
     }
 
-    public Monitor(final String id, final String monitor_type, final long version, final String name, final long interval, final String unit, final List<Input> inputs) {
+    public Monitor(final String id, final String monitor_type, final long version, final Schedule schedule, final String name, final long interval, final String unit, final List<Input> inputs) {
         this.id = id;
         this.monitor_type = monitor_type;
         this.version = version;
+        this.schedule = schedule;
         this.name = name;
         this.interval = interval;
         this.unit = unit;

--- a/src/main/java/org/opensearch/commons/model2/model/Monitor.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Monitor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+
+import java.util.List;
+
+public class Monitor extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Monitor.class);
+
+    public String id;
+    public String monitor_type;
+    public long version;
+    public String name;
+    public long interval;
+    public String unit;
+    public List<Input> inputs;
+
+    public Monitor() {
+        // for serialization
+    }
+
+    public Monitor(final String id, final String monitor_type, final long version, final String name, final long interval, final String unit, final List<Input> inputs) {
+        this.id = id;
+        this.monitor_type = monitor_type;
+        this.version = version;
+        this.name = name;
+        this.interval = interval;
+        this.unit = unit;
+        this.inputs = inputs;
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Query.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Query.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+import java.util.List;
+
+public class Query extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Query.class);
+
+    public String id;
+    public String name;
+    public String query;
+    public List<String> tags;
+
+    public Query() {
+        // for serialization
+    }
+
+    public Query(final String id, final String name, final String query, final List<String> tags) {
+        this.id = id;
+        this.name = name;
+        this.query = query;
+        this.tags = tags;
+    }
+
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Schedule.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Schedule.java
@@ -1,0 +1,31 @@
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+public class Schedule extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Schedule.class);
+
+    public String expression;
+    public ZoneId timezone;
+    public Integer interval;
+    public ChronoUnit unit;
+    public String type;
+
+    public Schedule() {
+        // for serialization
+    }
+
+    public Schedule(final String expression, final ZoneId timezone, final Integer interval, final ChronoUnit unit, final String type) {
+        this.expression = expression;
+        this.timezone = timezone;
+        this.interval = interval;
+        this.unit = unit;
+        this.type = type;
+    }
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Script.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Script.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+
+public class Script extends AbstractModel {
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Script.class);
+
+    public String source;
+    public String lang;
+
+    public Script() {
+        // for serialization
+    }
+
+    public Script(final String source, final String lang) {
+        this.source = source;
+        this.lang = lang;
+    }
+}
+

--- a/src/main/java/org/opensearch/commons/model2/model/Throttle.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Throttle.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+
+import java.time.temporal.ChronoUnit;
+
+public class Throttle extends AbstractModel {
+
+
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Throttle.class);
+
+    public int value;
+    public ChronoUnit unit;
+
+    public Throttle() {
+        // for serialization
+    }
+
+    public Throttle(final int value, final ChronoUnit unit) {
+        this.value = value;
+        this.unit = unit;
+    }
+
+}

--- a/src/main/java/org/opensearch/commons/model2/model/Trigger.java
+++ b/src/main/java/org/opensearch/commons/model2/model/Trigger.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2.model;
+
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.commons.model2.AbstractModel;
+import org.opensearch.commons.model2.ToXContentModel;
+
+import java.util.List;
+
+public class Trigger extends AbstractModel {
+    public static NamedXContentRegistry.Entry XCONTENT_REGISTRY = ToXContentModel.createRegistryEntry(Trigger.class);
+
+    public String id;
+    public String name;
+    public String severity;
+    public List<Action> actions;
+
+    public Trigger() {
+        // for serialization
+    }
+
+    public Trigger(final String id, final String name, final String severity, final List<Action> actions) {
+        this.id = id;
+        this.name = name;
+        this.severity = severity;
+        this.actions = actions;
+    }
+}

--- a/src/test/java/org/opensearch/commons/model2/ExampleIndexMonitorJSON.java
+++ b/src/test/java/org/opensearch/commons/model2/ExampleIndexMonitorJSON.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2;
+
+import org.json.JSONObject;
+
+public class ExampleIndexMonitorJSON {
+
+    public static String exampleIndexMonitor = "{\n" +
+            "  \"type\": \"monitor\",\n" +
+            "  \"monitor_type\": \"doc_level_monitor\",\n" +
+            "  \"name\": \"Example document-level monitor\",\n" +
+            "  \"enabled\": true,\n" +
+            "  \"schedule\": {\n" +
+            "    \"period\": {\n" +
+            "      \"interval\": 1,\n" +
+            "      \"unit\": \"MINUTES\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"inputs\": [\n" +
+            "    {\n" +
+            "        \"description\": \"Example document-level monitor for audit logs\",\n" +
+            "        \"indices\": [\n" +
+            "          \"audit-logs\"\n" +
+            "        ],\n" +
+            "        \"queries\": [\n" +
+            "        {\n" +
+            "            \"id\": \"nKQnFYABit3BxjGfiOXC\",\n" +
+            "            \"name\": \"sigma-123\",\n" +
+            "            \"query\": \"region:\\\"us-west-2\\\"\",\n" +
+            "            \"tags\": [\n" +
+            "                \"tag1\"\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        {\n" +
+            "            \"id\": \"gKQnABEJit3BxjGfiOXC\",\n" +
+            "            \"name\": \"sigma-456\",\n" +
+            "            \"query\": \"region:\\\"us-east-1\\\"\",\n" +
+            "            \"tags\": [\n" +
+            "                \"tag2\"\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        {\n" +
+            "            \"id\": \"h4J2ABEFNW3vxjGfiOXC\",\n" +
+            "            \"name\": \"sigma-789\",\n" +
+            "            \"query\": \"message:\\\"This is a SEPARATE error from IAD region\\\"\",\n" +
+            "            \"tags\": [\n" +
+            "                \"tag3\"\n" +
+            "            ]\n" +
+            "        }\n" +
+            "    ]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "    \"triggers\": [ { \"document_level_trigger\": {\n" +
+            "      \"name\": \"test-trigger\",\n" +
+            "      \"severity\": \"1\",\n" +
+            "      \"condition\": {\n" +
+            "        \"script\": {\n" +
+            "          \"source\": \"(query[name=sigma-123] || query[tag=tag3]) && query[name=sigma-789]\",\n" +
+            "          \"lang\": \"painless\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      \"actions\": [\n" +
+            "        {\n" +
+            "            \"name\": \"test-action\",\n" +
+            "            \"destination_id\": \"E4o5hnsB6KjPKmHtpfCA\",\n" +
+            "            \"message_template\": {\n" +
+            "                \"source\": \"Monitor  just entered alert status. Please investigate the issue. Related Finding Ids: , Related Document Ids: \",\n" +
+            "                \"lang\": \"mustache\"\n" +
+            "            },\n" +
+            "            \"action_execution_policy\": {\n" +
+            "                \"action_execution_scope\": {\n" +
+            "                    \"per_alert\": {\n" +
+            "                        \"actionable_alerts\": []\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            },\n" +
+            "            \"subject_template\": {\n" +
+            "                \"source\": \"The Subject\",\n" +
+            "                \"lang\": \"mustache\"\n" +
+            "            }\n" +
+            "         }\n" +
+            "      ]\n" +
+            "  }}]\n" +
+            "}";
+    public static JSONObject exampleIndexMonitorJSON = new JSONObject(exampleIndexMonitor);
+}

--- a/src/test/java/org/opensearch/commons/model2/ModelJSONParserTest.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelJSONParserTest.java
@@ -1,0 +1,25 @@
+package org.opensearch.commons.model2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.opensearch.commons.model2.model.Monitor;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ModelJSONParserTest {
+
+    private static final Logger LOG = LogManager.getLogger(ModelJSONParserTest.class);
+
+    @Test
+    public void testMonitorViaJSON() throws Exception {
+        JSONObject json = new JSONObject(new String(ExampleIndexMonitorJSON.exampleIndexMonitor.getBytes()));
+        final Monitor monitor = ModelSerializer.read(json, Monitor.class);
+        LOG.info(monitor);
+        assertNull(monitor.id);
+        assertNotNull(monitor.inputs);
+        assertNotNull(monitor.inputs.get(0).description);
+    }
+}

--- a/src/test/java/org/opensearch/commons/model2/ModelSerializerTest.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelSerializerTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.commons.model2;
 
+
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamInput;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -15,17 +16,19 @@ import org.opensearch.commons.model2.model.Action;
 import org.opensearch.commons.model2.model.Query;
 import org.opensearch.commons.model2.model.Script;
 import org.opensearch.commons.model2.model.Throttle;
-import org.opensearch.test.OpenSearchTestCase;
 
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-public class ModelSerializerTests extends OpenSearchTestCase {
+import static org.junit.Assert.assertEquals;
+
+
+public class ModelSerializerTest {
 
     @Test
     public void testWriter() throws Exception {
         final Query query1 = new Query("one", "two", "three", List.of("a", "b", "c"));
-        final Query query2 = ModelTests.serializeDeserialize(query1);
+        final Query query2 = ModelTest.serializeDeserialize(query1);
         assertEquals("one", query2.id);
         assertEquals("two", query2.name);
         assertEquals("three", query2.query);
@@ -36,7 +39,7 @@ public class ModelSerializerTests extends OpenSearchTestCase {
     @Test
     public void testEnumAccess() throws Exception {
         final Throttle throttle1 = new Throttle(10, ChronoUnit.SECONDS);
-        final Throttle throttle2 = ModelTests.serializeDeserialize(throttle1);
+        final Throttle throttle2 = ModelTest.serializeDeserialize(throttle1);
         assertEquals(throttle1, throttle2);
         assertEquals(10, throttle2.value);
         assertEquals(ChronoUnit.SECONDS, throttle2.unit);
@@ -45,7 +48,7 @@ public class ModelSerializerTests extends OpenSearchTestCase {
     @Test
     public void testNestedModels1() throws Exception {
         final Action.ExecutionScope.PerScope scope1 = new Action.ExecutionScope.PerScope(List.of("a", "b", "c"));
-        final Action.ExecutionScope.PerScope scope2 = ModelTests.serializeDeserialize(scope1);
+        final Action.ExecutionScope.PerScope scope2 = ModelTest.serializeDeserialize(scope1);
         assertEquals(scope1, scope2);
         assertEquals(scope1.actionable_alerts, scope2.actionable_alerts);
         assertEquals(scope1.actionable_alerts, scope2.actionable_alerts);
@@ -54,7 +57,7 @@ public class ModelSerializerTests extends OpenSearchTestCase {
     @Test
     public void testNestedModels2() throws Exception {
         final Action.ExecutionScope scope1 = new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("a", "b", "c")));
-        final Action.ExecutionScope scope2 = ModelTests.serializeDeserialize(scope1);
+        final Action.ExecutionScope scope2 = ModelTest.serializeDeserialize(scope1);
         assertEquals(scope1, scope2);
         assertEquals(scope1.per_alert, scope2.per_alert);
         assertEquals(scope1.per_alert.actionable_alerts, scope2.per_alert.actionable_alerts);
@@ -63,7 +66,7 @@ public class ModelSerializerTests extends OpenSearchTestCase {
     @Test
     public void testNestedModels3() throws Exception {
         final Action.ExecutionPolicy scope1 = new Action.ExecutionPolicy(new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("e", "f", "g"))));
-        final Action.ExecutionPolicy scope2 = ModelTests.serializeDeserialize(scope1);
+        final Action.ExecutionPolicy scope2 = ModelTest.serializeDeserialize(scope1);
         assertEquals(scope1, scope2);
         assertEquals(scope1.action_execution_scope, scope2.action_execution_scope);
         assertEquals(scope1.action_execution_scope.per_alert, scope2.action_execution_scope.per_alert);
@@ -72,7 +75,7 @@ public class ModelSerializerTests extends OpenSearchTestCase {
     @Test
     public void testNestedModels4() throws Exception {
         final Action scope1 = new Action("123", "an_action", "a_destination", new Script("here", "a"), new Script("here2", "b"), false, null, new Action.ExecutionPolicy(new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("e", "f", "g")))));
-        final Action scope2 = ModelTests.serializeDeserialize(scope1);
+        final Action scope2 = ModelTest.serializeDeserialize(scope1);
         assertEquals(scope1, scope2);
         assertEquals(scope1.action_execution_policy, scope2.action_execution_policy);
         assertEquals(scope1.action_execution_policy.action_execution_scope, scope2.action_execution_policy.action_execution_scope);

--- a/src/test/java/org/opensearch/commons/model2/ModelSerializerTests.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelSerializerTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2;
+
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamInput;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.commons.model2.model.Action;
+import org.opensearch.commons.model2.model.Query;
+import org.opensearch.commons.model2.model.Script;
+import org.opensearch.commons.model2.model.Throttle;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class ModelSerializerTests extends OpenSearchTestCase {
+
+    @Test
+    public void testWriter() throws Exception {
+        final Query query1 = new Query("one", "two", "three", List.of("a", "b", "c"));
+        final Query query2 = ModelTests.serializeDeserialize(query1);
+        assertEquals("one", query2.id);
+        assertEquals("two", query2.name);
+        assertEquals("three", query2.query);
+        assertEquals(List.of("a", "b", "c"), query2.tags);
+        assertEquals(query1, query2);
+    }
+
+    @Test
+    public void testEnumAccess() throws Exception {
+        final Throttle throttle1 = new Throttle(10, ChronoUnit.SECONDS);
+        final Throttle throttle2 = ModelTests.serializeDeserialize(throttle1);
+        assertEquals(throttle1, throttle2);
+        assertEquals(10, throttle2.value);
+        assertEquals(ChronoUnit.SECONDS, throttle2.unit);
+    }
+
+    @Test
+    public void testNestedModels1() throws Exception {
+        final Action.ExecutionScope.PerScope scope1 = new Action.ExecutionScope.PerScope(List.of("a", "b", "c"));
+        final Action.ExecutionScope.PerScope scope2 = ModelTests.serializeDeserialize(scope1);
+        assertEquals(scope1, scope2);
+        assertEquals(scope1.actionable_alerts, scope2.actionable_alerts);
+        assertEquals(scope1.actionable_alerts, scope2.actionable_alerts);
+    }
+
+    @Test
+    public void testNestedModels2() throws Exception {
+        final Action.ExecutionScope scope1 = new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("a", "b", "c")));
+        final Action.ExecutionScope scope2 = ModelTests.serializeDeserialize(scope1);
+        assertEquals(scope1, scope2);
+        assertEquals(scope1.per_alert, scope2.per_alert);
+        assertEquals(scope1.per_alert.actionable_alerts, scope2.per_alert.actionable_alerts);
+    }
+
+    @Test
+    public void testNestedModels3() throws Exception {
+        final Action.ExecutionPolicy scope1 = new Action.ExecutionPolicy(new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("e", "f", "g"))));
+        final Action.ExecutionPolicy scope2 = ModelTests.serializeDeserialize(scope1);
+        assertEquals(scope1, scope2);
+        assertEquals(scope1.action_execution_scope, scope2.action_execution_scope);
+        assertEquals(scope1.action_execution_scope.per_alert, scope2.action_execution_scope.per_alert);
+    }
+
+    @Test
+    public void testNestedModels4() throws Exception {
+        final Action scope1 = new Action("123", "an_action", "a_destination", new Script("here", "a"), new Script("here2", "b"), false, null, new Action.ExecutionPolicy(new Action.ExecutionScope(new Action.ExecutionScope.PerScope(List.of("e", "f", "g")))));
+        final Action scope2 = ModelTests.serializeDeserialize(scope1);
+        assertEquals(scope1, scope2);
+        assertEquals(scope1.action_execution_policy, scope2.action_execution_policy);
+        assertEquals(scope1.action_execution_policy.action_execution_scope, scope2.action_execution_policy.action_execution_scope);
+        assertEquals(scope1.action_execution_policy.action_execution_scope.per_alert, scope2.action_execution_policy.action_execution_scope.per_alert);
+    }
+
+    @Test
+    public void testXBuilder() throws Exception {
+        Query query = new Query("one", "two", "three", List.of("a", "b", "c"));
+        final BytesStreamOutput output = new BytesStreamOutput();
+        final XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON, output);
+        final BytesStreamInput input = new BytesStreamInput(output.bytes().toBytesRef().bytes);
+        //
+    }
+}

--- a/src/test/java/org/opensearch/commons/model2/ModelTest.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelTest.java
@@ -7,7 +7,6 @@ package org.opensearch.commons.model2;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.opensearch.common.io.stream.BytesStreamInput;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -18,34 +17,33 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
 
 import static org.opensearch.commons.model2.ModelSerializer.checkType;
 import static org.opensearch.commons.model2.ModelSerializer.getListGeneric;
 
-public class ModelTests extends OpenSearchTestCase {
+public class ModelTest extends OpenSearchTestCase {
 
-    private static final Logger LOG = LogManager.getLogger(ModelTests.class);
+    private static final Logger LOG = LogManager.getLogger(ModelTest.class);
 
-    public List<Class<?>> TEST_MODELS = new ArrayList<>();
+    public static List<Class<?>> TEST_MODELS = List.of(
+            Action.class,
+            Action.ExecutionPolicy.class,
+            Action.ExecutionScope.class,
+            Action.ExecutionScope.PerScope.class,
+            Input.class,
+            Monitor.class,
+            Query.class,
+            Script.class,
+            Throttle.class,
+            Trigger.class);
 
     private static final int NULL_FIELD_PROBABILITY = 10;
     private static final List<String> ALPHABET = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_", "-");
 
-    @BeforeClass
-    public void loadModelsForTesting() {
-        Collections.addAll(TEST_MODELS,
-                Action.class,
-                Action.ExecutionPolicy.class,
-                Action.ExecutionScope.class,
-                Action.ExecutionScope.PerScope.class,
-                Input.class,
-                Monitor.class,
-                Query.class,
-                Script.class,
-                Throttle.class,
-                Trigger.class);
-    }
 
     @Test
     public void testModels() throws Exception {
@@ -70,7 +68,7 @@ public class ModelTests extends OpenSearchTestCase {
 
             LOG.info("\tVerifying stream input/output serialization consistency for {}", modelClass);
             // TODO: test against all stream output/input types
-            assertEquals(modelA, ModelTests.serializeDeserialize((ToXContentModel) modelA));
+            assertEquals(modelA, ModelTest.serializeDeserialize((ToXContentModel) modelA));
             for (final Field field : ModelSerializer.getSortedFields(modelClass)) {
                 assertEquals(field.get(modelA), field.get(modelB));
             }

--- a/src/test/java/org/opensearch/commons/model2/ModelTest.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelTest.java
@@ -7,25 +7,27 @@ package org.opensearch.commons.model2;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.opensearch.common.io.stream.BytesStreamInput;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.commons.model2.model.*;
-import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.opensearch.commons.model2.ModelSerializer.checkType;
 import static org.opensearch.commons.model2.ModelSerializer.getListGeneric;
 
-public class ModelTest extends OpenSearchTestCase {
+public class ModelTest  {
 
     private static final Logger LOG = LogManager.getLogger(ModelTest.class);
 
@@ -37,13 +39,13 @@ public class ModelTest extends OpenSearchTestCase {
             Input.class,
             Monitor.class,
             Query.class,
+            Schedule.class,
             Script.class,
             Throttle.class,
             Trigger.class);
 
     private static final int NULL_FIELD_PROBABILITY = 10;
     private static final List<String> ALPHABET = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_", "-");
-
 
     @Test
     public void testModels() throws Exception {
@@ -97,6 +99,8 @@ public class ModelTest extends OpenSearchTestCase {
                         field.set(model, ChronoUnit.values()[random.nextInt(ChronoUnit.values().length)]);
                     else if (checkType(field, List.class, String.class))
                         field.set(model, nextListString(random));
+                    else if (checkType(field, ZoneId.class))
+                        field.set(model, ZoneId.of(new ArrayList<>(ZoneId.getAvailableZoneIds()).get(random.nextInt(ZoneId.getAvailableZoneIds().size()))));
                     else if (checkType(field, List.class))
                         field.set(model, nextList(random, getListGeneric(field)));
                     else if (checkType(field, ToXContentModel.class))

--- a/src/test/java/org/opensearch/commons/model2/ModelTests.java
+++ b/src/test/java/org/opensearch/commons/model2/ModelTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.model2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensearch.common.io.stream.BytesStreamInput;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.commons.model2.model.*;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static org.opensearch.commons.model2.ModelSerializer.checkType;
+import static org.opensearch.commons.model2.ModelSerializer.getListGeneric;
+
+public class ModelTests extends OpenSearchTestCase {
+
+    private static final Logger LOG = LogManager.getLogger(ModelTests.class);
+
+    public List<Class<?>> TEST_MODELS = new ArrayList<>();
+
+    private static final int NULL_FIELD_PROBABILITY = 10;
+    private static final List<String> ALPHABET = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "_", "-");
+
+    @BeforeClass
+    public void loadModelsForTesting() {
+        Collections.addAll(TEST_MODELS,
+                Action.class,
+                Action.ExecutionPolicy.class,
+                Action.ExecutionScope.class,
+                Action.ExecutionScope.PerScope.class,
+                Input.class,
+                Monitor.class,
+                Query.class,
+                Script.class,
+                Throttle.class,
+                Trigger.class);
+    }
+
+    @Test
+    public void testModels() throws Exception {
+        final Random random = new Random();
+        final long seed = random.nextInt();
+        for (Class<?> modelClass : TEST_MODELS) {
+            LOG.info("Testing {}", modelClass.getName());
+            // TODO make model instance population parameterized
+            final Object modelA = createModel(new Random(seed), modelClass);
+            final Object modelB = createModel(new Random(seed), modelClass);
+            final Object modelC = createModel(random, modelClass);
+            final Object modelD = createModel(random, modelClass);
+            LOG.info("\tModel instances: \n\tmodelA: {}\n\tmodelB: {}\n\tmodelC: {}\n\tmodelD: {}", modelA, modelB, modelC, modelD);
+            assertEquals(modelA, modelB);
+            assertNotEquals(modelA, modelC);
+            assertNotEquals(modelA, modelD);
+            assertNotEquals(modelB, modelC);
+            assertNotEquals(modelB, modelD);
+            assertNotEquals(modelC, modelD);
+            assertEquals(modelA.hashCode(), modelB.hashCode());
+            assertEquals(3, new HashSet<>(List.of(modelA, modelB, modelC, modelD)).size());
+
+            LOG.info("\tVerifying stream input/output serialization consistency for {}", modelClass);
+            // TODO: test against all stream output/input types
+            assertEquals(modelA, ModelTests.serializeDeserialize((ToXContentModel) modelA));
+            for (final Field field : ModelSerializer.getSortedFields(modelClass)) {
+                assertEquals(field.get(modelA), field.get(modelB));
+            }
+
+            // TODO: test XContent parser/builder
+        }
+    }
+
+    public static <T> T createModel(final Random random, final Class<T> modelClass) {
+        try {
+            final T model = modelClass.getConstructor().newInstance();
+            for (final Field field : ModelSerializer.getSortedFields(modelClass)) {
+                final boolean isNull = random.nextInt(100) < NULL_FIELD_PROBABILITY;
+                if (!isNull) {
+                    if (checkType(field, boolean.class))
+                        field.set(model, random.nextBoolean());
+                    else if (checkType(field, String.class))
+                        field.set(model, nextString(random));
+                    else if (checkType(field, long.class))
+                        field.set(model, random.nextLong());
+                    else if (checkType(field, int.class))
+                        field.set(model, random.nextInt());
+                    else if (checkType(field, TimeValue.class))
+                        field.set(model, new TimeValue(Math.abs(random.nextLong())));
+                    else if (checkType(field, ChronoUnit.class))
+                        field.set(model, ChronoUnit.values()[random.nextInt(ChronoUnit.values().length)]);
+                    else if (checkType(field, List.class, String.class))
+                        field.set(model, nextListString(random));
+                    else if (checkType(field, List.class))
+                        field.set(model, nextList(random, getListGeneric(field)));
+                    else if (checkType(field, ToXContentModel.class))
+                        field.set(model, createModel(random, field.getType()));
+                }
+            }
+            return model;
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String nextString(final Random random) {
+        final int length = random.nextInt(10) + 1;
+        String string = "";
+        for (int i = 0; i < length; i++) {
+            string = string + ALPHABET.get(random.nextInt(ALPHABET.size()));
+        }
+        return string;
+    }
+
+    public static List<String> nextListString(final Random random) {
+        final int length = random.nextInt(10) + 1;
+        final List<String> list = new ArrayList<>();
+        for (int i = 0; i < length; i++) {
+            list.add(nextString(random));
+        }
+        return list;
+    }
+
+    public static <T> List<T> nextList(final Random random, final Class<T> type) {
+        final int length = random.nextInt(10) + 1;
+        final List<T> list = new ArrayList<>();
+        for (int i = 0; i < length; i++) {
+            list.add(createModel(random, type));
+        }
+        return list;
+    }
+
+    public static <T extends ToXContentModel> T serializeDeserialize(final T model) {
+        try {
+            final BytesStreamOutput output = new BytesStreamOutput();
+            ModelSerializer.write(output, model);
+            final BytesStreamInput input = new BytesStreamInput(output.bytes().toBytesRef().bytes);
+            return ModelSerializer.read(input, (Class<T>) model.getClass());
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T extends ToXContentModel> T xcontentReadWrite(final T model) {
+        try {
+            final BytesStreamOutput output = new BytesStreamOutput();
+            ModelSerializer.write(output, model);
+            final BytesStreamInput input = new BytesStreamInput(output.bytes().toBytesRef().bytes);
+            return ModelSerializer.read(input, (Class<T>) model.getClass());
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
This is related to ISSUE-10 of security analytics. It's the best push I have that uses a simpler Model infrastructure based on public fields and reflection. It also incorporates the notion of redirecting existing actions to a intermediate "translator action" (@getsaurabh02 idea). 

This is a 3 part PR across common-utils, alerting, and security analytics. All under the same `model2/` branch.

*CheckList:*
[X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/alerting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).