### PR TITLE
expose delete monitor api from alerting

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
@@ -9,6 +9,8 @@ import org.opensearch.action.ActionResponse
 import org.opensearch.client.node.NodeClient
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.commons.alerting.action.AlertingActions
+import org.opensearch.commons.alerting.action.DeleteMonitorRequest
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.action.IndexMonitorRequest
 import org.opensearch.commons.alerting.action.IndexMonitorResponse
 import org.opensearch.commons.notifications.action.BaseResponse
@@ -36,6 +38,24 @@ object AlertingPluginInterface {
             wrapActionListener(listener) { response ->
                 recreateObject(response) {
                     IndexMonitorResponse(
+                        it
+                    )
+                }
+            }
+        )
+    }
+
+    fun deleteMonitor(
+        client: NodeClient,
+        request: DeleteMonitorRequest,
+        listener: ActionListener<DeleteMonitorResponse>
+    ) {
+        client.execute(
+            AlertingActions.DELETE_MONITOR_ACTION_TYPE,
+            request,
+            wrapActionListener(listener) { response ->
+                recreateObject(response) {
+                    DeleteMonitorResponse(
                         it
                     )
                 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
@@ -11,4 +11,9 @@ object AlertingActions {
 
     val INDEX_MONITOR_ACTION_TYPE =
         ActionType(INDEX_MONITOR_ACTION_NAME, ::IndexMonitorResponse)
+
+    const val DELETE_MONITOR_ACTION_NAME = "cluster:admin/opendistro/alerting/monitor/delete"
+
+    val DELETE_MONITOR_ACTION_TYPE =
+        ActionType(DELETE_MONITOR_ACTION_NAME, ::DeleteMonitorResponse)
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
@@ -1,0 +1,35 @@
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import java.io.IOException
+
+class DeleteMonitorRequest : ActionRequest {
+
+    val monitorId: String
+    val refreshPolicy: WriteRequest.RefreshPolicy
+
+    constructor(monitorId: String, refreshPolicy: WriteRequest.RefreshPolicy) : super() {
+        this.monitorId = monitorId
+        this.refreshPolicy = refreshPolicy
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        monitorId = sin.readString(),
+        refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin)
+    )
+
+    override fun validate(): ActionRequestValidationException? {
+        return null
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(monitorId)
+        refreshPolicy.writeTo(out)
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorResponse.kt
@@ -1,0 +1,38 @@
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.io.stream.StreamOutput
+import org.opensearch.common.xcontent.ToXContent
+import org.opensearch.common.xcontent.XContentBuilder
+import org.opensearch.commons.alerting.util.IndexUtils
+import org.opensearch.commons.notifications.action.BaseResponse
+
+class DeleteMonitorResponse : BaseResponse {
+    var id: String
+    var version: Long
+
+    constructor(
+        id: String,
+        version: Long
+    ) : super() {
+        this.id = id
+        this.version = version
+    }
+
+    constructor(sin: StreamInput) : this(
+        sin.readString(), // id
+        sin.readLong() // version
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeLong(version)
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        return builder.startObject()
+            .field(IndexUtils._ID, id)
+            .field(IndexUtils._VERSION, version)
+            .endObject()
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
+import org.opensearch.commons.alerting.action.DeleteMonitorRequest
+import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.action.IndexMonitorRequest
 import org.opensearch.commons.alerting.action.IndexMonitorResponse
 import org.opensearch.commons.alerting.model.Monitor
@@ -39,6 +41,22 @@ internal class AlertingPluginInterfaceTests {
         }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
 
         AlertingPluginInterface.indexMonitor(client, request, listener)
+        Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
+    }
+
+    @Test
+    fun deleteMonitor() {
+        val request = mock(DeleteMonitorRequest::class.java)
+        val response = DeleteMonitorResponse(Monitor.NO_ID, Monitor.NO_VERSION)
+        val listener: ActionListener<DeleteMonitorResponse> =
+            mock(ActionListener::class.java) as ActionListener<DeleteMonitorResponse>
+
+        Mockito.doAnswer {
+            (it.getArgument(2) as ActionListener<DeleteMonitorResponse>)
+                .onResponse(response)
+        }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
+
+        AlertingPluginInterface.deleteMonitor(client, request, listener)
         Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequestTests.kt
@@ -1,0 +1,26 @@
+package org.opensearch.commons.alerting.action
+
+import org.junit.Assert
+import org.junit.Test
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.io.stream.StreamInput
+
+class DeleteMonitorRequestTests {
+
+    @Test
+    fun `test delete monitor request`() {
+
+        val req = DeleteMonitorRequest("1234", WriteRequest.RefreshPolicy.IMMEDIATE)
+        Assert.assertNotNull(req)
+        Assert.assertEquals("1234", req.monitorId)
+        Assert.assertEquals("true", req.refreshPolicy.value)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = DeleteMonitorRequest(sin)
+        Assert.assertEquals("1234", newReq.monitorId)
+        Assert.assertEquals("true", newReq.refreshPolicy.value)
+    }
+}


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
expose delete monitor api from alerting
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
