### PR TITLE
Change TrustStoreTest to use File.separator to support Windows path

### DIFF
--- a/src/test/java/org/opensearch/commons/rest/TrustStoreTest.java
+++ b/src/test/java/org/opensearch/commons/rest/TrustStoreTest.java
@@ -20,7 +20,7 @@ public class TrustStoreTest {
     public void testCreate() throws Exception {
         String resourceName = "sample.pem";
         String absolutePath = new File(getClass().getClassLoader().getResource(resourceName).getFile()).getAbsolutePath();
-        assertTrue(absolutePath.endsWith("/sample.pem"));
+        assertTrue(absolutePath.endsWith(File.separator + "sample.pem"));
 
         KeyStore store = new TrustStore(absolutePath).create();
         assertNotNull(store);


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Change TrustStoreTest to use File.separator to support Windows path.
Thanks @rishabhmaurya for the fix on this.
 
### Issues Resolved
#238 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
