### PR TITLE
Migrate to Apache HttpClient / Core 5.x

### DIFF
--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -14,7 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.Strings;
@@ -83,7 +84,7 @@ final public class User implements Writeable, ToXContent {
      * @param response
      * @throws IOException
      */
-    public User(final Response response) throws IOException {
+    public User(final Response response) throws IOException, ParseException {
         this(EntityUtils.toString(response.getEntity()));
     }
 

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
@@ -10,7 +10,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 
-import org.apache.http.client.utils.URIBuilder;
+import org.apache.hc.core5.net.URIBuilder;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;

--- a/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessage.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
+import org.apache.hc.client5.http.classic.methods.HttpPatch;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpPut;
 import org.opensearch.common.Strings;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;

--- a/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
+++ b/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
@@ -18,15 +18,20 @@ import java.util.Arrays;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
@@ -96,7 +101,7 @@ public class SecureRestClientBuilder {
         this.passwd = passWord;
         this.settings = Settings.EMPTY;
         this.configPath = null;
-        hosts.add(new HttpHost(host, port, httpSSLEnabled ? ConfigConstants.HTTPS : ConfigConstants.HTTP));
+        hosts.add(new HttpHost(httpSSLEnabled ? ConfigConstants.HTTPS : ConfigConstants.HTTP, host, port));
     }
 
     /**
@@ -129,7 +134,7 @@ public class SecureRestClientBuilder {
         this.passwd = null;
         String host = ConfigConstants.HOST_DEFAULT;
         int port = settings.getAsInt(ConfigConstants.HTTP_PORT, ConfigConstants.HTTP_PORT_DEFAULT);
-        hosts.add(new HttpHost(host, port, httpSSLEnabled ? ConfigConstants.HTTPS : ConfigConstants.HTTP));
+        hosts.add(new HttpHost(httpSSLEnabled ? ConfigConstants.HTTPS : ConfigConstants.HTTP, host, port));
     }
 
     /**
@@ -172,9 +177,9 @@ public class SecureRestClientBuilder {
             @Override
             public RequestConfig.Builder customizeRequestConfig(RequestConfig.Builder requestConfigBuilder) {
                 return requestConfigBuilder
-                    .setConnectTimeout(defaultConnectTimeOutMSecs)
-                    .setSocketTimeout(defaultSoTimeoutMSecs)
-                    .setConnectionRequestTimeout(defaultConnRequestTimeoutMSecs);
+                    .setConnectTimeout(Timeout.ofMilliseconds(defaultConnectTimeOutMSecs))
+                    .setResponseTimeout(Timeout.ofMilliseconds(defaultSoTimeoutMSecs))
+                    .setConnectionRequestTimeout(Timeout.ofMilliseconds(defaultConnRequestTimeoutMSecs));
             }
         });
 
@@ -189,7 +194,12 @@ public class SecureRestClientBuilder {
             @Override
             public HttpAsyncClientBuilder customizeHttpClient(HttpAsyncClientBuilder httpClientBuilder) {
                 if (sslContext != null) {
-                    httpClientBuilder.setSSLContext(sslContext);
+                    TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create().setSslContext(sslContext).build();
+                    PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+                        .create()
+                        .setTlsStrategy(tlsStrategy)
+                        .build();
+                    httpClientBuilder.setConnectionManager(connectionManager);
                 }
                 if (credentialsProvider != null) {
                     httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
@@ -227,8 +237,8 @@ public class SecureRestClientBuilder {
         if (Strings.isNullOrEmpty(user) || Strings.isNullOrEmpty(passwd))
             return null;
 
-        final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, passwd));
+        final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(null, -1), new UsernamePasswordCredentials(user, passwd.toCharArray()));
         return credentialsProvider;
     }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -1,7 +1,7 @@
 package org.opensearch.commons.alerting.model
 
 import org.apache.commons.validator.routines.UrlValidator
-import org.apache.http.client.utils.URIBuilder
+import org.apache.hc.core5.net.URIBuilder
 import org.opensearch.common.CheckedFunction
 import org.opensearch.common.ParseField
 import org.opensearch.common.io.stream.StreamInput

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
@@ -12,8 +12,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.io.stream.StreamInput;

--- a/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
+++ b/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.Request;

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -3,8 +3,8 @@ package org.opensearch.commons.alerting
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers
 import com.carrotsearch.randomizedtesting.generators.RandomStrings
 import junit.framework.TestCase.assertNull
-import org.apache.http.Header
-import org.apache.http.HttpEntity
+import org.apache.hc.core5.http.Header
+import org.apache.hc.core5.http.HttpEntity
 import org.opensearch.client.Request
 import org.opensearch.client.RequestOptions
 import org.opensearch.client.Response

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
@@ -91,7 +91,7 @@ class ClusterMetricsInputTests {
         // GIVEN
         path = "/_cluster/health/"
         pathParams = "index1,index2,index3,index4,index5"
-        url = "http://localhost:9200/_cluster/health/index1,index2,index3,index4,index5"
+        url = "http://localhost:9200/_cluster/health/index1%2Cindex2%2Cindex3%2Cindex4%2Cindex5"
 
         // WHEN
         val clusterMetricsInput = ClusterMetricsInput(path, pathParams, url)
@@ -207,7 +207,7 @@ class ClusterMetricsInputTests {
         // GIVEN
         path = "/_cluster/health/"
         pathParams = "index1,index2,index3,index4,index5"
-        val testUrl = "http://localhost:9200/_cluster/health/index1,index2,index3,index4,index5"
+        val testUrl = "http://localhost:9200/_cluster/health/index1%2Cindex2%2Cindex3%2Cindex4%2Cindex5"
         val clusterMetricsInput = ClusterMetricsInput(path, pathParams, url)
 
         // WHEN
@@ -437,6 +437,6 @@ class ClusterMetricsInputTests {
         // THEN
         assertEquals(path, clusterMetricsInput.path)
         assertEquals(pathParams, clusterMetricsInput.pathParams)
-        assertEquals(testUrl, clusterMetricsInput.url)
+        assertEquals(testUrl.replace(",", "%2C"), clusterMetricsInput.url)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
@@ -91,7 +91,7 @@ class ClusterMetricsInputTests {
         // GIVEN
         path = "/_cluster/health/"
         pathParams = "index1,index2,index3,index4,index5"
-        url = "http://localhost:9200/_cluster/health/index1%2Cindex2%2Cindex3%2Cindex4%2Cindex5"
+        url = "http://localhost:9200/_cluster/health/index1,index2,index3,index4,index5"
 
         // WHEN
         val clusterMetricsInput = ClusterMetricsInput(path, pathParams, url)
@@ -207,7 +207,7 @@ class ClusterMetricsInputTests {
         // GIVEN
         path = "/_cluster/health/"
         pathParams = "index1,index2,index3,index4,index5"
-        val testUrl = "http://localhost:9200/_cluster/health/index1%2Cindex2%2Cindex3%2Cindex4%2Cindex5"
+        val testUrl = "http://localhost:9200/_cluster/health/index1,index2,index3,index4,index5"
         val clusterMetricsInput = ClusterMetricsInput(path, pathParams, url)
 
         // WHEN
@@ -437,6 +437,6 @@ class ClusterMetricsInputTests {
         // THEN
         assertEquals(path, clusterMetricsInput.path)
         assertEquals(pathParams, clusterMetricsInput.pathParams)
-        assertEquals(testUrl.replace(",", "%2C"), clusterMetricsInput.url)
+        assertEquals(testUrl, clusterMetricsInput.url)
     }
 }


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
this PR fixes the build failures in `common-utils` due to `upgrade of Apache HttpClient / Core to 5.x` in `opensearch-core`.
https://github.com/opensearch-project/OpenSearch/commit/4833e080cc506237fee5aa90767d6f49d952bec3
 
### Issues Resolved
#279
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
