### PR TITLE
add list of alert ids in get alerts request

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequest.kt
@@ -14,6 +14,7 @@ class GetAlertsRequest : ActionRequest {
     val monitorId: String?
     val alertIndex: String?
     val monitorIds: List<String>?
+    val alertIds: List<String>?
 
     constructor(
         table: Table,
@@ -21,7 +22,8 @@ class GetAlertsRequest : ActionRequest {
         alertState: String,
         monitorId: String?,
         alertIndex: String?,
-        monitorIds: List<String>? = null
+        monitorIds: List<String>? = null,
+        alertIds: List<String>? = null
     ) : super() {
         this.table = table
         this.severityLevel = severityLevel
@@ -29,6 +31,7 @@ class GetAlertsRequest : ActionRequest {
         this.monitorId = monitorId
         this.alertIndex = alertIndex
         this.monitorIds = monitorIds
+        this.alertIds = alertIds
     }
 
     @Throws(IOException::class)
@@ -38,7 +41,8 @@ class GetAlertsRequest : ActionRequest {
         alertState = sin.readString(),
         monitorId = sin.readOptionalString(),
         alertIndex = sin.readOptionalString(),
-        monitorIds = sin.readOptionalStringList()
+        monitorIds = sin.readOptionalStringList(),
+        alertIds = sin.readOptionalStringList()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -53,5 +57,6 @@ class GetAlertsRequest : ActionRequest {
         out.writeOptionalString(monitorId)
         out.writeOptionalString(alertIndex)
         out.writeOptionalStringCollection(monitorIds)
+        out.writeOptionalStringCollection(alertIds)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequestTests.kt
@@ -16,7 +16,7 @@ internal class GetAlertsRequestTests {
 
         val table = Table("asc", "sortString", null, 1, 0, "")
 
-        val req = GetAlertsRequest(table, "1", "active", null, null, listOf("1", "2"))
+        val req = GetAlertsRequest(table, "1", "active", null, null, listOf("1", "2"), listOf("alert1", "alert2"))
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -30,6 +30,8 @@ internal class GetAlertsRequestTests {
         assertEquals(table, newReq.table)
         assertTrue(newReq.monitorIds!!.contains("1"))
         assertTrue(newReq.monitorIds!!.contains("2"))
+        assertTrue(newReq.alertIds!!.contains("alert1"))
+        assertTrue(newReq.alertIds!!.contains("alert2"))
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Surya Sashank Nistala <snistala@amazon.com>

Related to [[FEATURE] Fetching or acknowledging alert by passing alert id without monitor Id #602](https://github.com/opensearch-project/alerting/issues/602)