### PR TITLE
Added function for request recreation that considers the writeable re…

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
@@ -7,6 +7,7 @@ package org.opensearch.commons.alerting
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionResponse
 import org.opensearch.client.node.NodeClient
+import org.opensearch.common.io.stream.NamedWriteableRegistry
 import org.opensearch.common.io.stream.Writeable
 import org.opensearch.commons.alerting.action.AcknowledgeAlertRequest
 import org.opensearch.commons.alerting.action.AcknowledgeAlertResponse
@@ -43,6 +44,31 @@ object AlertingPluginInterface {
             request,
             wrapActionListener(listener) { response ->
                 recreateObject(response) {
+                    IndexMonitorResponse(
+                        it
+                    )
+                }
+            }
+        )
+    }
+    /**
+     * Index monitor interface.
+     * @param client Node client for making transport action
+     * @param request The request object
+     * @param namedWriteableRegistry Registry for building aggregations
+     * @param listener The listener for getting response
+     */
+    fun indexMonitor(
+        client: NodeClient,
+        request: IndexMonitorRequest,
+        namedWriteableRegistry: NamedWriteableRegistry,
+        listener: ActionListener<IndexMonitorResponse>
+    ) {
+        client.execute(
+            AlertingActions.INDEX_MONITOR_ACTION_TYPE,
+            request,
+            wrapActionListener(listener) { response ->
+                recreateObject(response, namedWriteableRegistry) {
                     IndexMonitorResponse(
                         it
                     )

--- a/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
@@ -32,29 +32,6 @@ object AlertingPluginInterface {
      * Index monitor interface.
      * @param client Node client for making transport action
      * @param request The request object
-     * @param listener The listener for getting response
-     */
-    fun indexMonitor(
-        client: NodeClient,
-        request: IndexMonitorRequest,
-        listener: ActionListener<IndexMonitorResponse>
-    ) {
-        client.execute(
-            AlertingActions.INDEX_MONITOR_ACTION_TYPE,
-            request,
-            wrapActionListener(listener) { response ->
-                recreateObject(response) {
-                    IndexMonitorResponse(
-                        it
-                    )
-                }
-            }
-        )
-    }
-    /**
-     * Index monitor interface.
-     * @param client Node client for making transport action
-     * @param request The request object
      * @param namedWriteableRegistry Registry for building aggregations
      * @param listener The listener for getting response
      */
@@ -76,7 +53,6 @@ object AlertingPluginInterface {
             }
         )
     }
-
     fun deleteMonitor(
         client: NodeClient,
         request: DeleteMonitorRequest,

--- a/src/main/kotlin/org/opensearch/commons/utils/TransportHelpers.kt
+++ b/src/main/kotlin/org/opensearch/commons/utils/TransportHelpers.kt
@@ -6,6 +6,8 @@
 package org.opensearch.commons.utils
 
 import org.opensearch.common.io.stream.InputStreamStreamInput
+import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput
+import org.opensearch.common.io.stream.NamedWriteableRegistry
 import org.opensearch.common.io.stream.OutputStreamStreamOutput
 import org.opensearch.common.io.stream.StreamInput
 import org.opensearch.common.io.stream.StreamOutput
@@ -32,6 +34,22 @@ inline fun <reified Request> recreateObject(writeable: Writeable, block: (Stream
             writeable.writeTo(it)
             InputStreamStreamInput(ByteArrayInputStream(byteArrayOutputStream.toByteArray())).use { streamInput ->
                 return block(streamInput)
+            }
+        }
+    }
+}
+
+/**
+ * Re create the object from the writeable. Uses NamedWriteableRegistry in order to build the aggregations.
+ * This method needs to be inline and reified so that when this is called from
+ * doExecute() of transport action, the object may be created from other JVM.
+ */
+inline fun <reified Request> recreateObject(writeable: Writeable, namedWriteableRegistry: NamedWriteableRegistry, block: (StreamInput) -> Request): Request {
+    ByteArrayOutputStream().use { byteArrayOutputStream ->
+        OutputStreamStreamOutput(byteArrayOutputStream).use {
+            writeable.writeTo(it)
+            InputStreamStreamInput(ByteArrayInputStream(byteArrayOutputStream.toByteArray())).use { streamInput ->
+                return block(NamedWriteableAwareStreamInput(streamInput, namedWriteableRegistry))
             }
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.opensearch.action.ActionListener
 import org.opensearch.action.ActionType
 import org.opensearch.client.node.NodeClient
+import org.opensearch.common.io.stream.NamedWriteableRegistry
+import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.action.DeleteMonitorRequest
 import org.opensearch.commons.alerting.action.DeleteMonitorResponse
 import org.opensearch.commons.alerting.action.GetAlertsRequest
@@ -25,6 +27,7 @@ import org.opensearch.commons.alerting.model.FindingWithDocs
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.index.seqno.SequenceNumbers
 import org.opensearch.rest.RestStatus
+import org.opensearch.search.SearchModule
 
 @Suppress("UNCHECKED_CAST")
 @ExtendWith(MockitoExtension::class)
@@ -48,6 +51,25 @@ internal class AlertingPluginInterfaceTests {
         }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
 
         AlertingPluginInterface.indexMonitor(client, request, listener)
+        Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
+    }
+
+    @Test
+    fun indexBucketMonitor() {
+        val monitor = randomBucketLevelMonitor()
+
+        val request = mock(IndexMonitorRequest::class.java)
+        val response = IndexMonitorResponse(Monitor.NO_ID, Monitor.NO_VERSION, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, monitor)
+        val listener: ActionListener<IndexMonitorResponse> =
+            mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+        val namedWriteableRegistry = NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)
+
+        Mockito.doAnswer {
+            (it.getArgument(2) as ActionListener<IndexMonitorResponse>)
+                .onResponse(response)
+        }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
+        AlertingPluginInterface.indexMonitor(client, request, namedWriteableRegistry, listener)
+        Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
         Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
     }
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
@@ -44,13 +44,14 @@ internal class AlertingPluginInterfaceTests {
         val response = IndexMonitorResponse(Monitor.NO_ID, Monitor.NO_VERSION, SequenceNumbers.UNASSIGNED_SEQ_NO, SequenceNumbers.UNASSIGNED_PRIMARY_TERM, monitor)
         val listener: ActionListener<IndexMonitorResponse> =
             mock(ActionListener::class.java) as ActionListener<IndexMonitorResponse>
+        val namedWriteableRegistry = NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)
 
         Mockito.doAnswer {
             (it.getArgument(2) as ActionListener<IndexMonitorResponse>)
                 .onResponse(response)
         }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
 
-        AlertingPluginInterface.indexMonitor(client, request, listener)
+        AlertingPluginInterface.indexMonitor(client, request, namedWriteableRegistry, listener)
         Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
     }
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
@@ -4,10 +4,16 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput
+import org.opensearch.common.io.stream.NamedWriteableRegistry
 import org.opensearch.common.io.stream.StreamInput
+import org.opensearch.common.settings.Settings
 import org.opensearch.commons.alerting.model.SearchInput
+import org.opensearch.commons.alerting.randomBucketLevelMonitor
 import org.opensearch.commons.alerting.randomQueryLevelMonitor
+import org.opensearch.commons.utils.recreateObject
 import org.opensearch.rest.RestRequest
+import org.opensearch.search.SearchModule
 import org.opensearch.search.builder.SearchSourceBuilder
 
 class IndexMonitorRequestTests {
@@ -30,6 +36,42 @@ class IndexMonitorRequestTests {
         Assertions.assertEquals(2L, newReq.primaryTerm)
         Assertions.assertEquals(RestRequest.Method.POST, newReq.method)
         Assertions.assertNotNull(newReq.monitor)
+    }
+
+    @Test
+    fun `test index bucket monitor post request`() {
+        val req = IndexMonitorRequest(
+            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            randomBucketLevelMonitor()
+        )
+        Assertions.assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val namedWriteableRegistry = NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)
+        val newReq = IndexMonitorRequest(NamedWriteableAwareStreamInput(sin, namedWriteableRegistry))
+        Assertions.assertEquals("1234", newReq.monitorId)
+        Assertions.assertEquals(1L, newReq.seqNo)
+        Assertions.assertEquals(2L, newReq.primaryTerm)
+        Assertions.assertEquals(RestRequest.Method.POST, newReq.method)
+        Assertions.assertNotNull(newReq.monitor)
+    }
+
+    @Test
+    fun `Index bucket monitor serialize and deserialize transport object should be equal`() {
+        val req = IndexMonitorRequest(
+            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            randomBucketLevelMonitor()
+        )
+
+        val recreatedObject = recreateObject(req, NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)) { IndexMonitorRequest(it) }
+        Assertions.assertEquals(req.monitorId, recreatedObject.monitorId)
+        Assertions.assertEquals(req.seqNo, recreatedObject.seqNo)
+        Assertions.assertEquals(req.primaryTerm, recreatedObject.primaryTerm)
+        Assertions.assertEquals(req.method, recreatedObject.method)
+        Assertions.assertNotNull(recreatedObject.monitor)
+        Assertions.assertEquals(req.monitor, recreatedObject.monitor)
     }
 
     @Test

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
@@ -60,18 +60,22 @@ class IndexMonitorRequestTests {
 
     @Test
     fun `Index bucket monitor serialize and deserialize transport object should be equal`() {
-        val req = IndexMonitorRequest(
+        val bucketLevelMonitorRequest = IndexMonitorRequest(
             "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
             randomBucketLevelMonitor()
         )
 
-        val recreatedObject = recreateObject(req, NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)) { IndexMonitorRequest(it) }
-        Assertions.assertEquals(req.monitorId, recreatedObject.monitorId)
-        Assertions.assertEquals(req.seqNo, recreatedObject.seqNo)
-        Assertions.assertEquals(req.primaryTerm, recreatedObject.primaryTerm)
-        Assertions.assertEquals(req.method, recreatedObject.method)
+        Assertions.assertThrows(UnsupportedOperationException::class.java) {
+            recreateObject(bucketLevelMonitorRequest) { IndexMonitorRequest(it) }
+        }
+
+        val recreatedObject = recreateObject(bucketLevelMonitorRequest, NamedWriteableRegistry(SearchModule(Settings.EMPTY, emptyList()).namedWriteables)) { IndexMonitorRequest(it) }
+        Assertions.assertEquals(bucketLevelMonitorRequest.monitorId, recreatedObject.monitorId)
+        Assertions.assertEquals(bucketLevelMonitorRequest.seqNo, recreatedObject.seqNo)
+        Assertions.assertEquals(bucketLevelMonitorRequest.primaryTerm, recreatedObject.primaryTerm)
+        Assertions.assertEquals(bucketLevelMonitorRequest.method, recreatedObject.method)
         Assertions.assertNotNull(recreatedObject.monitor)
-        Assertions.assertEquals(req.monitor, recreatedObject.monitor)
+        Assertions.assertEquals(bucketLevelMonitorRequest.monitor, recreatedObject.monitor)
     }
 
     @Test


### PR DESCRIPTION
…gistry used for parsing the aggregations

Added unit tests that checks if the bucket level monitor requests are created and ser/de correctly

Signed-off-by: Stevan Buzejic <stevan.buzejic@htecgroup.com>

### Description
This PR enables serialization/de-serialization of bucket level monitors. 
Adds two new methods - recreateObject which is responsible to re-create objects by using the namedWriteableRegistry
and indexMonitor - which calls recreateObject taking into the account namedWriteableRegistry
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
