### PR TITLE
Add a super admin client builder w/ hosts params

### DIFF
--- a/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
+++ b/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
@@ -138,6 +138,15 @@ public class SecureRestClientBuilder {
         hosts.add(new HttpHost(httpSSLEnabled ? ConfigConstants.HTTPS : ConfigConstants.HTTP, host, port));
     }
 
+    public SecureRestClientBuilder(Settings settings, Path configPath, HttpHost[] httpHosts) {
+        this.httpSSLEnabled = settings.getAsBoolean(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, false);
+        this.settings = settings;
+        this.configPath = configPath;
+        this.user = null;
+        this.passwd = null;
+        hosts.addAll(Arrays.asList(httpHosts));
+    }
+
     /**
      * Creates a low-level Rest client.
      * @return


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

### Description
Duplicate the super admin client constructor with hosts params. Currently we hardcode the host to be localhost:9200 in super admin client.
 
### Issues Resolved
https://github.com/opensearch-project/index-management/issues/612
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
