### PR TITLE
Update keystore password to utilize secure variants

### DIFF
--- a/src/main/java/org/opensearch/commons/ConfigConstants.java
+++ b/src/main/java/org/opensearch/commons/ConfigConstants.java
@@ -5,6 +5,10 @@
 
 package org.opensearch.commons;
 
+import org.opensearch.common.settings.SecureSetting;
+import org.opensearch.common.settings.SecureString;
+import org.opensearch.common.settings.Setting;
+
 public class ConfigConstants {
 
     public static final String HTTPS = "https";
@@ -19,8 +23,33 @@ public class ConfigConstants {
     // These reside in security plugin.
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH = "plugins.security.ssl.http.pemcert_filepath";
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH = "plugins.security.ssl.http.keystore_filepath";
+    /**
+     * @deprecated in favor of the {@link #OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING} secure setting
+     */
+    @Deprecated
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD = "plugins.security.ssl.http.keystore_password";
+
+    /**
+     * @deprecated in favor of the {@link #OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING} secure setting
+     */
+    @Deprecated
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD = "plugins.security.ssl.http.keystore_keypassword";
+    private static final String SECURE_SUFFIX = "_secure";
+
+    private static Setting<SecureString> createFallbackInsecureSetting(String key) {
+        return new Setting<>(key, (settings) -> "", (strValue) -> new SecureString(strValue.toCharArray()));
+    }
+
+    public static final Setting<SecureString> OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING = SecureSetting
+        .secureString(
+            OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD + SECURE_SUFFIX,
+            createFallbackInsecureSetting(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD)
+        );
+    public static final Setting<SecureString> OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING = SecureSetting
+        .secureString(
+            OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD + SECURE_SUFFIX,
+            createFallbackInsecureSetting(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD)
+        );
     public static final String OPENSEARCH_SECURITY_INJECTED_ROLES = "opendistro_security_injected_roles";
     public static final String INJECTED_USER = "injected_user";
     public static final String OPENSEARCH_SECURITY_USE_INJECTED_USER_FOR_PLUGINS = "plugins.security_use_injected_user_for_plugins";

--- a/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
+++ b/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
@@ -289,13 +289,13 @@ public class SecureRestClientBuilder {
     }
 
     private String getKeystorePasswd() {
-        return settings.get(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD, null);
+        return ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING.get(settings).toString();
     }
 
     private KeyStore getKeyStore() throws IOException, GeneralSecurityException {
         KeyStore keyStore = KeyStore.getInstance("jks");
         String keyStoreFile = settings.get(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, null);
-        String passwd = settings.get(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, null);
+        String passwd = ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING.get(settings).toString();
         if (Strings.isNullOrEmpty(keyStoreFile) || Strings.isNullOrEmpty(passwd)) {
             return null;
         }

--- a/src/test/java/org/opensearch/commons/ConfigConstantsTest.java
+++ b/src/test/java/org/opensearch/commons/ConfigConstantsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.Settings;
+
+public class ConfigConstantsTest {
+    private void assertPasswords(Settings settings, String expectedPassword, String expectedKeyPassword) {
+        final var password = ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING.get(settings);
+        Assertions.assertEquals(expectedPassword, password.toString());
+
+        final var keyPassword = ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING.get(settings);
+        Assertions.assertEquals(expectedKeyPassword, keyPassword.toString());
+    }
+
+    @Test
+    public void testLegacyHttpKeystorePassword() {
+        final var settings = Settings
+            .builder()
+            .put("plugins.security.ssl.http.keystore_password", "legacy-password")
+            .put("plugins.security.ssl.http.keystore_keypassword", "legacy-keypassword")
+            .build();
+
+        assertPasswords(settings, "legacy-password", "legacy-keypassword");
+    }
+
+    @Test
+    public void testSecureHttpKeystorePassword() {
+        final var mockSecureSettings = new MockSecureSettings();
+        // deliberately not using constants here to verify correct concatenation of legacy + _secure suffix
+        mockSecureSettings.setString("plugins.security.ssl.http.keystore_password_secure", "password");
+        mockSecureSettings.setString("plugins.security.ssl.http.keystore_keypassword_secure", "keypassword");
+
+        final var settings = Settings
+            .builder()
+            // check priority that secure variants are taken over the legacy ones
+            .put("plugins.security.ssl.http.keystore_password", "legacy-password")
+            .put("plugins.security.ssl.http.keystore_keypassword", "legacy-keypassword")
+            .setSecureSettings(mockSecureSettings)
+            .build();
+
+        assertPasswords(settings, "password", "keypassword");
+    }
+}

--- a/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
+++ b/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_ENABLED;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
-import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING;
+import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH;
 
 import java.io.File;
@@ -24,6 +24,8 @@ import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestClient;
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.SecureSettings;
 import org.opensearch.common.settings.Settings;
 
 @Disabled("Enable this after integration with security plugin is done")
@@ -34,6 +36,13 @@ public class IntegrationTests {
         RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
         request.setOptions(builder);
         return request;
+    }
+
+    protected SecureSettings createSecureSettings() {
+        MockSecureSettings mockSecureSettings = new MockSecureSettings();
+        mockSecureSettings.setString(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING.getKey(), "changeit");
+        mockSecureSettings.setString(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING.getKey(), "changeit");
+        return mockSecureSettings;
     }
 
     @Test
@@ -56,8 +65,7 @@ public class IntegrationTests {
             .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, true)
             .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
             .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, "changeit")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD, "changeit")
+            .setSecureSettings(createSecureSettings())
             .build();
 
         RestClient client = new SecureRestClientBuilder(settings, configPath).build();
@@ -77,8 +85,7 @@ public class IntegrationTests {
             .put("http.port", 9200)
             .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, true)
             .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, "changeit")
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD, "changeit")
+            .setSecureSettings(createSecureSettings())
             .build();
 
         RestClient client = new SecureRestClientBuilder(settings, configPath).build();


### PR DESCRIPTION
### Description
Update configuration use of keystore passwords to utilize secure variants when present, falling back to the insecure variants for legacy reasons

Related to changes introduced to security plugin in PR:
* https://github.com/opensearch-project/security/pull/2296 
 
### Issues Resolved
#334 