### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,14 +1,16 @@
-## Maintainers
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
 
 | Maintainer       | GitHub ID                                         | Affiliation |
-|------------------|---------------------------------------------------| ----------- |
-| Ashish Agrawal   | [lezzago](https://github.com/lezzago)             | Amazon |
-| Mohammad Qureshi | [qreshi](https://github.com/qreshi)               | Amazon |
-| Sriram Kosuri    | [skkosuri-amzn](https://github.com/skkosuri-amzn) | Amazon |
-| Bowen Lan        | [bowenlan-amzn](https://github.com/bowenlan-amzn) | Amazon |
-| Rishabh Maurya   | [rishabhmaurya](https://github.com/rishabhmaurya) | Amazon | 
-| Tianli Feng      | [tlfeng](https://github.com/tlfeng)               | Amazon |
-| Annie Lee        | [leeyun-amzn](https://github.com/leeyun-amzn)     | Amazon |
-| Saurabh Singh    | [getsaurabh02](https://github.com/getsaurabh02)    | Amazon |
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+| ---------------- | ------------------------------------------------- | ----------- |
+| Ashish Agrawal   | [lezzago](https://github.com/lezzago)             | Amazon      |
+| Mohammad Qureshi | [qreshi](https://github.com/qreshi)               | Amazon      |
+| Sriram Kosuri    | [skkosuri-amzn](https://github.com/skkosuri-amzn) | Amazon      |
+| Bowen Lan        | [bowenlan-amzn](https://github.com/bowenlan-amzn) | Amazon      |
+| Rishabh Maurya   | [rishabhmaurya](https://github.com/rishabhmaurya) | Amazon      |
+| Tianli Feng      | [tlfeng](https://github.com/tlfeng)               | Amazon      |
+| Annie Lee        | [leeyun-amzn](https://github.com/leeyun-amzn)     | Amazon      |
+| Saurabh Singh    | [getsaurabh02](https://github.com/getsaurabh02)   | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.