### PR TITLE
2.x branch - Publish snapshots to maven via GHA

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishPluginZipPublicationToSnapshotsRepository
+          ./gradlew publishAllPublicationsToSnapshotsRepository

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,39 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [
+        main
+          1.*
+          2.*
+    ]
+
+jobs:
+  build-and-publish-snapshots:
+    strategy:
+      fail-fast: false
+    if: github.repository == 'opensearch-project/common-utils'
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 17
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,4 +36,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishAllPublicationsToSnapshotsRepository
+          ./gradlew publishShadowPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,14 @@ publishing {
             name = 'staging'
             url = "${rootProject.buildDir}/local-staging-repo"
         }
+        maven {
+            name = "Snapshots"
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
     }
     publications {
         shadow(MavenPublication) {


### PR DESCRIPTION
### Description
Publish snapshots to maven via GHA.
Cherry-picked the changes in the `main` branch PR https://github.com/opensearch-project/common-utils/pull/362
 
### Issues Resolved
https://github.com/opensearch-project/common-utils/issues/361

### Tests
Tested locally on my `2.x`-based branch.
```
$ find snapshots | sort   
snapshots
snapshots/org
snapshots/org/opensearch
snapshots/org/opensearch/common-utils
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-javadoc.jar
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-javadoc.jar.md5
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-javadoc.jar.sha1
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-javadoc.jar.sha256
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-javadoc.jar.sha512
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-sources.jar
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-sources.jar.md5
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-sources.jar.sha1
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-sources.jar.sha256
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1-sources.jar.sha512
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.jar
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.jar.md5
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.jar.sha1
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.jar.sha256
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.jar.sha512
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.pom
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.pom.md5
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.pom.sha1
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.pom.sha256
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/common-utils-2.6.0.0-20230222.015350-1.pom.sha512
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/maven-metadata.xml
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/maven-metadata.xml.md5
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/maven-metadata.xml.sha1
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/maven-metadata.xml.sha256
snapshots/org/opensearch/common-utils/2.6.0.0-SNAPSHOT/maven-metadata.xml.sha512
snapshots/org/opensearch/common-utils/maven-metadata.xml
snapshots/org/opensearch/common-utils/maven-metadata.xml.md5
snapshots/org/opensearch/common-utils/maven-metadata.xml.sha1
snapshots/org/opensearch/common-utils/maven-metadata.xml.sha256
snapshots/org/opensearch/common-utils/maven-metadata.xml.sha512

```
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
