### PR TITLE
Fix SNS regex for validation on notification channel to support SNS FIFO topics.

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Sns.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Sns.kt
@@ -58,7 +58,7 @@ data class Sns(val topicArn: String, val roleArn: String?) : BaseConfigData {
         private val log by logger(Sns::class.java)
 
         private val SNS_ARN_REGEX =
-            Pattern.compile("^arn:aws(-[^:]+)?:sns:([a-zA-Z0-9-]+):([0-9]{12}):([a-zA-Z0-9-_]+)$")
+            Pattern.compile("^arn:aws(-[^:]+)?:sns:([a-zA-Z0-9-]+):([0-9]{12}):([a-zA-Z_0-9+=,.@\\-_/]+)$")
 
         /**
          * reader to create instance of class from writable.

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/SnsTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/SnsTests.kt
@@ -8,6 +8,7 @@ package org.opensearch.commons.notifications.model
 import com.fasterxml.jackson.core.JsonParseException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.opensearch.commons.utils.createObjectFromJsonString
 import org.opensearch.commons.utils.getJsonString
@@ -46,6 +47,18 @@ internal class SnsTests {
             "{\"topic_arn\":\"arn:aws:sns:us-east-1:012345678912:topic-test\",\"role_arn\":\"arn:aws:iam:us-east-1:0123456789:role-test\"}"
         assertThrows(IllegalArgumentException::class.java) {
             createObjectFromJsonString(jsonString) { Sns.parse(it) }
+        }
+    }
+
+    @Test
+    fun `test SNS correctly validates SNS FIFO topic ARN`() {
+        try {
+            Sns(
+                "arn:aws:sns:ap-southeast-2:333654771707:sns-fifo-alerting.fifo",
+                "arn:aws:iam::012345678912:role/iam-test"
+            )
+        } catch (e: Exception) {
+            fail("Expected fifo sns topic ARN to be validated successfully", e)
         }
     }
 


### PR DESCRIPTION
### Description
Fixed SNS regex for validation on notification channel to support SNS FIFO topics.


SNS FIFO topic ARN regex validation was throwing error
`java.lang.IllegalArgumentException: Invalid AWS SNS topic ARN: arn:aws:sns:ap-southeast-2:33365477133:sns-fifo-alerting.fifo`


 
### Issues Resolved
#382 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
