### PR TITLE
Extended DeleteMonitorRequest with workflowMetadataId used when delet…

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
@@ -11,16 +11,19 @@ class DeleteMonitorRequest : ActionRequest {
 
     val monitorId: String
     val refreshPolicy: WriteRequest.RefreshPolicy
+    val workflowMetadataId: String?
 
-    constructor(monitorId: String, refreshPolicy: WriteRequest.RefreshPolicy) : super() {
+    constructor(monitorId: String, refreshPolicy: WriteRequest.RefreshPolicy, workflowMetadataId: String? = null) : super() {
         this.monitorId = monitorId
         this.refreshPolicy = refreshPolicy
+        this.workflowMetadataId = workflowMetadataId
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         monitorId = sin.readString(),
-        refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin)
+        refreshPolicy = WriteRequest.RefreshPolicy.readFrom(sin),
+        workflowMetadataId = sin.readOptionalString()
     )
 
     override fun validate(): ActionRequestValidationException? {
@@ -31,5 +34,6 @@ class DeleteMonitorRequest : ActionRequest {
     override fun writeTo(out: StreamOutput) {
         out.writeString(monitorId)
         refreshPolicy.writeTo(out)
+        out.writeOptionalString(workflowMetadataId)
     }
 }


### PR DESCRIPTION
### Description
Added workflowMetadataId used when deleting the monitors
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
