### PR TITLE
Switch publish maven branches to list

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,11 +3,10 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-    branches: [
-        main
-          1.*
-          2.*
-    ]
+    branches: 
+      - 'main'
+      - '1.*'
+      - '2.*'
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description
Switches format of branches to run publish maven on to list. In https://github.com/opensearch-project/common-utils/actions/workflows/maven-publish.yml, all workflows are being triggered manually instead of push. This will allow workflow to be triggered on push to respective branches.

See k-NN: 
1. https://github.com/opensearch-project/k-NN/blob/main/.github/workflows/maven-publish.yml
2. https://github.com/opensearch-project/k-NN/actions/workflows/maven-publish.yml
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
