### PR TITLE
Sync up MAINTAINERS to CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/common-utils
+* @lezzago @qreshi @skkosuri-amzn @bowenlan-amzn @rishabhmaurya @tlfeng @getsaurabh02

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,5 +12,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Bowen Lan        | [bowenlan-amzn](https://github.com/bowenlan-amzn) | Amazon      |
 | Rishabh Maurya   | [rishabhmaurya](https://github.com/rishabhmaurya) | Amazon      |
 | Tianli Feng      | [tlfeng](https://github.com/tlfeng)               | Amazon      |
-| Annie Lee        | [leeyun-amzn](https://github.com/leeyun-amzn)     | Amazon      |
 | Saurabh Singh    | [getsaurabh02](https://github.com/getsaurabh02)   | Amazon      |
+
+## Emeritus
+
+| Maintainer       | GitHub ID                                         | Affiliation |
+| ---------------- | ------------------------------------------------- | ----------- |
+| Annie Lee        | [leeyun-amzn](https://github.com/leeyun-amzn)     | Amazon      |
+


### PR DESCRIPTION
### Description

Sync up MAINTAINERS to CODEOWNERS.

### Issues Resolved

Closes https://github.com/opensearch-project/common-utils/issues/357.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
