### PR TITLE
accept workflow argument in chained alert constructor

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
@@ -56,9 +56,9 @@ data class Alert(
         schemaVersion: Int = NO_SCHEMA_VERSION,
         executionId: String,
         chainedAlertTrigger: ChainedAlertTrigger,
-        user: User
+        workflow: Workflow
     ) : this(
-        monitorId = NO_ID, monitorName = "", monitorVersion = NO_VERSION, monitorUser = user,
+        monitorId = NO_ID, monitorName = "", monitorVersion = NO_VERSION, monitorUser = workflow.user,
         triggerId = chainedAlertTrigger.id, triggerName = chainedAlertTrigger.name, state = state, startTime = startTime,
         lastNotificationTime = lastNotificationTime, errorMessage = errorMessage, errorHistory = emptyList(),
         severity = chainedAlertTrigger.severity, actionExecutionResults = emptyList(), schemaVersion = schemaVersion,


### PR DESCRIPTION
accept workflow argument in chained alert constructor. Workflow would contain id, name and user fields which make it a good dto to pass along similar to how other types of alerts accept monitor object in constructor