### PR TITLE
Modify triggers to push snapshots on all branches

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -4,10 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: 
-      - 'main'
-      - '1.*'
-      - '2.*'
-
+      - main
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
 jobs:
   build-and-publish-snapshots:
     strategy:


### PR DESCRIPTION
### Description
Modify triggers to push snapshots on all branches. See history here: https://github.com/opensearch-project/common-utils/actions/workflows/maven-publish.yml
We had to manually trigger the workflow many times. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
