### PR TITLE
Implemented support for configuring a cluster metrics monitor to call cat/indices, and cat/shards.

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -261,6 +261,13 @@ data class ClusterMetricsInput(
         val requiresPathParams: Boolean
     ) {
         BLANK("", "", "", false, false),
+        CAT_INDICES(
+            "/_cat/indices",
+            "/_cat/indices",
+            "",
+            true,
+            false
+        ),
         CAT_PENDING_TASKS(
             "/_cat/pending_tasks",
             "/_cat/pending_tasks",
@@ -271,6 +278,13 @@ data class ClusterMetricsInput(
         CAT_RECOVERY(
             "/_cat/recovery",
             "/_cat/recovery",
+            "",
+            true,
+            false
+        ),
+        CAT_SHARDS(
+            "/_cat/shards",
+            "/_cat/shards",
             "",
             true,
             false

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -395,7 +395,10 @@ fun randomDocLevelMonitorInput(
 }
 
 fun randomClusterMetricsInput(
-    path: String = ClusterMetricsInput.ClusterMetricType.CLUSTER_HEALTH.defaultPath,
+    path: String = ClusterMetricsInput.ClusterMetricType.values()
+        .filter { it.defaultPath.isNotBlank() && !it.requiresPathParams }
+        .random()
+        .defaultPath,
     pathParams: String = "",
     url: String = ""
 ): ClusterMetricsInput {


### PR DESCRIPTION
### Description
Implemented support for configuring a cluster metrics monitor to call cat/indices, and cat/shards.
Documentation issue https://github.com/opensearch-project/documentation-website/issues/4437
 
### Issues Resolved
https://github.com/opensearch-project/alerting/issues/611
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
