### PR TITLE
obfuscate ip addresses in alert error message

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/alerts/AlertError.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/alerts/AlertError.kt
@@ -61,7 +61,7 @@ data class AlertError(val timestamp: Instant, var message: String) : Writeable, 
 
         fun obfuscateIPAddresses(exceptionMessage: String): String {
             val ipAddressPattern = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
-            val obfuscatedMessage = exceptionMessage.replace(ipAddressPattern.toRegex(), "X.X.X.X")
+            val obfuscatedMessage = exceptionMessage.replace(ipAddressPattern.toRegex(), "x.x.x.x")
             return obfuscatedMessage
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/alerting/alerts/AlertError.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/alerts/AlertError.kt
@@ -12,7 +12,10 @@ import org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken
 import java.io.IOException
 import java.time.Instant
 
-data class AlertError(val timestamp: Instant, val message: String) : Writeable, ToXContent {
+data class AlertError(val timestamp: Instant, var message: String) : Writeable, ToXContent {
+    init {
+        this.message = obfuscateIPAddresses(message)
+    }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -54,6 +57,12 @@ data class AlertError(val timestamp: Instant, val message: String) : Writeable, 
         @Throws(IOException::class)
         fun readFrom(sin: StreamInput): AlertError {
             return AlertError(sin)
+        }
+
+        fun obfuscateIPAddresses(exceptionMessage: String): String {
+            val ipAddressPattern = "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+            val obfuscatedMessage = exceptionMessage.replace(ipAddressPattern.toRegex(), "X.X.X.X")
+            return obfuscatedMessage
         }
     }
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/alerts/AlertErrorTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/alerts/AlertErrorTests.kt
@@ -1,0 +1,25 @@
+package org.opensearch.commons.alerting.alerts
+
+import org.junit.Assert
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AlertErrorTests {
+
+    @Test
+    fun `test alertError obfuscates IP addresses in message`() {
+        val message =
+            "AlertingException[[5f32db4e2a4fa94f6778cb895dae7a24][10.212.77.91:9300][indices:admin/create]]; " +
+                "nested: Exception[org.opensearch.transport.RemoteTransportException: [5f32db4e2a4fa94f6778cb895dae7a24][10.212.77.91:9300]" +
+                "[indices:admin/create]];; java.lang.Exception: org.opensearch.transport.RemoteTransportException: [5f32db4e2a4fa94f6778cb895" +
+                "dae7a24][10.212.77.91:9300][indices:admin/create]"
+        val alertError = AlertError(Instant.now(), message = message)
+        Assert.assertEquals(
+            alertError.message,
+            "AlertingException[[5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300][indices:admin/create]]; " +
+                "nested: Exception[org.opensearch.transport.RemoteTransportException: [5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300]" +
+                "[indices:admin/create]];; java.lang.Exception: org.opensearch.transport.RemoteTransportException: " +
+                "[5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300][indices:admin/create]"
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/alerts/AlertErrorTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/alerts/AlertErrorTests.kt
@@ -16,10 +16,10 @@ class AlertErrorTests {
         val alertError = AlertError(Instant.now(), message = message)
         Assert.assertEquals(
             alertError.message,
-            "AlertingException[[5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300][indices:admin/create]]; " +
-                "nested: Exception[org.opensearch.transport.RemoteTransportException: [5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300]" +
+            "AlertingException[[5f32db4e2a4fa94f6778cb895dae7a24][x.x.x.x:9300][indices:admin/create]]; " +
+                "nested: Exception[org.opensearch.transport.RemoteTransportException: [5f32db4e2a4fa94f6778cb895dae7a24][x.x.x.x:9300]" +
                 "[indices:admin/create]];; java.lang.Exception: org.opensearch.transport.RemoteTransportException: " +
-                "[5f32db4e2a4fa94f6778cb895dae7a24][X.X.X.X:9300][indices:admin/create]"
+                "[5f32db4e2a4fa94f6778cb895dae7a24][x.x.x.x:9300][indices:admin/create]"
         )
     }
 }


### PR DESCRIPTION
### Description
Currently alertError class' message field is storing exception messages along with IP addresses if message contains any IPs

This change obfuscates the ip address in exception messages stored in disk and shown to user