### PR TITLE
[Breaking Change] Corrects the security config constant name which uses trusted cas

### DIFF
--- a/src/main/java/org/opensearch/commons/ConfigConstants.java
+++ b/src/main/java/org/opensearch/commons/ConfigConstants.java
@@ -21,7 +21,7 @@ public class ConfigConstants {
     public static final String AUTHORIZATION = "Authorization";
 
     // These reside in security plugin.
-    public static final String OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH = "plugins.security.ssl.http.pemcert_filepath";
+    public static final String OPENSEARCH_SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = "plugins.security.ssl.http.pemtrustedcas_filepath";
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH = "plugins.security.ssl.http.keystore_filepath";
     /**
      * @deprecated in favor of the {@link #OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING} secure setting

--- a/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
+++ b/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
@@ -310,7 +310,7 @@ public class SecureRestClientBuilder {
     }
 
     private String getTrustPem() {
-        return settings.get(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, null);
+        return settings.get(ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, null);
     }
 
     private String getKeystorePasswd() {

--- a/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
+++ b/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
@@ -11,7 +11,7 @@ import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTT
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD_SETTING;
 import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD_SETTING;
-import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH;
+import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -63,7 +63,7 @@ public class IntegrationTests {
             .builder()
             .put("http.port", 9200)
             .put(OPENSEARCH_SECURITY_SSL_HTTP_ENABLED, true)
-            .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "sample.pem")
+            .put(OPENSEARCH_SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "sample.pem")
             .put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_FILEPATH, "test-kirk.jks")
             .setSecureSettings(createSecureSettings())
             .build();

--- a/src/test/java/org/opensearch/commons/rest/SecureRestClientBuilderTest.java
+++ b/src/test/java/org/opensearch/commons/rest/SecureRestClientBuilderTest.java
@@ -60,7 +60,7 @@ public class SecureRestClientBuilderTest {
                 .builder()
                 .put("http.port", 9200)
                 .put("plugins.security.ssl.http.enabled", true)
-                .put("plugins.security.ssl.http.pemcert_filepath", "sample.pem")
+                .put("plugins.security.ssl.http.pemtrustedcas_filepath", "sample.pem")
                 .build();
             new SecureRestClientBuilder(settings, Paths.get("sample.pem")).build();
         });


### PR DESCRIPTION
### Description
SecureRestClientBuilder currently is using node-certificate constant `pemcert_filepath` to build trust store. This is incorrect. It should be using `pemtrustedcas_filepath` to build a trust-store with root CAs
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
