### PR TITLE
support list of monitor ids in Chained Monitor Findings

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
@@ -30,7 +30,7 @@ class IndexWorkflowRequest : ActionRequest {
         refreshPolicy: WriteRequest.RefreshPolicy,
         method: RestRequest.Method,
         workflow: Workflow,
-        rbacRoles: List<String>? = null
+        rbacRoles: List<String>? = null,
     ) : super() {
         this.workflowId = workflowId
         this.seqNo = seqNo
@@ -105,19 +105,41 @@ class IndexWorkflowRequest : ActionRequest {
         val monitorIdOrderMap: Map<String, Int> = delegates.associate { it.monitorId to it.order }
         delegates.forEach {
             if (it.chainedMonitorFindings != null) {
-                if (monitorIdOrderMap.containsKey(it.chainedMonitorFindings.monitorId) == false) {
-                    validationException = ValidateActions.addValidationError(
-                        "Chained Findings Monitor ${it.chainedMonitorFindings.monitorId} doesn't exist in sequence",
-                        validationException
-                    )
-                    // Break the flow because next check will generate the NPE
-                    return validationException
-                }
-                if (it.order <= monitorIdOrderMap[it.chainedMonitorFindings.monitorId]!!) {
-                    validationException = ValidateActions.addValidationError(
-                        "Chained Findings Monitor ${it.chainedMonitorFindings.monitorId} should be executed before monitor ${it.monitorId}",
-                        validationException
-                    )
+
+                if (it.chainedMonitorFindings.monitorId != null) {
+                    if (monitorIdOrderMap.containsKey(it.chainedMonitorFindings.monitorId) == false) {
+                        validationException = ValidateActions.addValidationError(
+                            "Chained Findings Monitor ${it.chainedMonitorFindings.monitorId} doesn't exist in sequence",
+                            validationException
+                        )
+                        // Break the flow because next check will generate the NPE
+                        return validationException
+                    }
+                    if (it.order <= monitorIdOrderMap[it.chainedMonitorFindings.monitorId]!!) {
+                        validationException = ValidateActions.addValidationError(
+                            "Chained Findings Monitor ${it.chainedMonitorFindings.monitorId} should be executed before monitor ${it.monitorId}",
+                            validationException
+                        )
+                    }
+                } else {
+                    for (monitorId in it.chainedMonitorFindings.monitorIds) {
+                        if (!monitorIdOrderMap.containsKey(monitorId)) {
+                            validationException = ValidateActions.addValidationError(
+                                "Chained Findings Monitor $monitorId doesn't exist in sequence",
+                                validationException
+                            )
+                            return validationException
+                        } else {
+                            val order = monitorIdOrderMap.get(monitorId)!!
+                            if (order >= it.order) {
+                                return ValidateActions.addValidationError(
+                                    "Chained Findings Monitor ${it.chainedMonitorFindings.monitorId} should be executed before monitor ${it.monitorId}. " +
+                                        "Order of monitor being chained [$order] should be smaller than order of monitor using findings as source data [${it.order}] in sequence",
+                                    validationException
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
@@ -30,7 +30,7 @@ class IndexWorkflowRequest : ActionRequest {
         refreshPolicy: WriteRequest.RefreshPolicy,
         method: RestRequest.Method,
         workflow: Workflow,
-        rbacRoles: List<String>? = null,
+        rbacRoles: List<String>? = null
     ) : super() {
         this.workflowId = workflowId
         this.seqNo = seqNo

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
@@ -75,8 +75,8 @@ data class ChainedMonitorFindings(
 
                 when (fieldName) {
                     MONITOR_ID_FIELD -> {
-                        if(!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL))
-                        monitorId = xcp.text()
+                        if (!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL))
+                            monitorId = xcp.text()
                     }
 
                     MONITOR_IDS_FIELD -> {

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
@@ -24,7 +24,7 @@ data class ChainedMonitorFindings(
         require(!(monitorId.isNullOrBlank() && monitorIds.isEmpty())) {
             "at least one of fields, 'monitorIds' and 'monitorId' should be provided"
         }
-        if(monitorId!= null && monitorId.isBlank()) {
+        if (monitorId != null && monitorId.isBlank()) {
             validateId(monitorId)
         } else {
             monitorIds.forEach { validateId(it) }
@@ -66,7 +66,7 @@ data class ChainedMonitorFindings(
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): ChainedMonitorFindings {
-            lateinit var monitorId: String
+            var monitorId: String? = null
             val monitorIds = mutableListOf<String>()
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -75,8 +75,8 @@ data class ChainedMonitorFindings(
 
                 when (fieldName) {
                     MONITOR_ID_FIELD -> {
+                        if(!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL))
                         monitorId = xcp.text()
-                        validateId(monitorId)
                     }
 
                     MONITOR_IDS_FIELD -> {

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -405,6 +405,11 @@ fun randomClusterMetricsInput(
     return ClusterMetricsInput(path, pathParams, url)
 }
 
+fun ChainedMonitorFindings.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
 fun Workflow.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContentWithUser(builder, ToXContent.EMPTY_PARAMS).string()

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/CompositeInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/CompositeInputTests.kt
@@ -70,9 +70,24 @@ class CompositeInputTests {
     }
 
     @Test
-    fun `test create Chained Findings with illegal monitorId value`() {
+    fun `test create Chained Findings with illegal monitorId value and empty monitorIds list`() {
         try {
             ChainedMonitorFindings("")
+            Assertions.fail("Expecting an illegal argument exception")
+        } catch (e: IllegalArgumentException) {
+            e.message?.let {
+                Assertions.assertTrue(
+                    it.contains("at least one of fields, 'monitorIds' and 'monitorId' should be provided")
+
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `test create Chained Findings with null monitorId value and  monitorIds list with blank monitorIds`() {
+        try {
+            ChainedMonitorFindings("", listOf("", ""))
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             e.message?.let {

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -267,10 +267,25 @@ class XContentTests {
     @Test
     fun `test workflow parsing`() {
         val workflow = randomWorkflow(monitorIds = listOf("1", "2", "3"))
-
         val monitorString = workflow.toJsonString()
         val parsedWorkflow = Workflow.parse(parser(monitorString))
         Assertions.assertEquals(workflow, parsedWorkflow, "Round tripping workflow failed")
+    }
+
+    @Test
+    fun `test chainedMonitorFindings parsing`() {
+        val cmf1 = ChainedMonitorFindings(monitorId = "m1")
+        val cmf1String = cmf1.toJsonString()
+        Assertions.assertEquals(
+            ChainedMonitorFindings.parse(parser(cmf1String)), cmf1,
+            "Round tripping chained monitor findings failed"
+        )
+        val cmf2 = ChainedMonitorFindings(monitorIds = listOf("m1", "m2"))
+        val cmf2String = cmf2.toJsonString()
+        Assertions.assertEquals(
+            ChainedMonitorFindings.parse(parser(cmf2String)), cmf2,
+            "Round tripping chained monitor findings failed"
+        )
     }
 
     @Test


### PR DESCRIPTION
Adds support for passing a list monitor ids in chained monitor findings. This helps filter data of a monitor in workflow based on findings of multiple monitors instead of a single monitor.

If workflow sequence looks like: 
[m1] -> [m2] -> [m3 (chained findings of m1, m2)]
this means m3's data input would be the related doc ids from findings of m1 and m2.

for backward compatibility reasons, the monitorId field would be given preference over the new list type field, monitorIds, if both are provided.