### PR TITLE
(Backport 2.x) support list of monitor ids in Chained Monitor Findings (#514)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
@@ -9,50 +9,65 @@ import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.core.xcontent.XContentParser
 import org.opensearch.core.xcontent.XContentParserUtils
 import java.io.IOException
+import java.util.Collections
 
 /**
- * Context passed in delegate monitor to filter data queried by a monitor based on the findings of the given monitor id.
+ * Context passed in delegate monitor to filter data matched by a list of monitors based on the findings of the given monitor ids.
  */
 // TODO - Remove the class and move the monitorId to Delegate (as a chainedMonitorId property) if this class won't be updated by adding new properties
 data class ChainedMonitorFindings(
-    val monitorId: String
+    val monitorId: String? = null,
+    val monitorIds: List<String> = emptyList(), // if monitorId field is non-null it would be given precendence for BWC
 ) : BaseModel {
 
     init {
-        validateId(monitorId)
+        require(!(monitorId.isNullOrBlank() && monitorIds.isEmpty())) {
+            "at least one of fields, 'monitorIds' and 'monitorId' should be provided"
+        }
+        if (monitorId != null && monitorId.isBlank()) {
+            validateId(monitorId)
+        } else {
+            monitorIds.forEach { validateId(it) }
+        }
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
-        sin.readString(), // monitorId
+        sin.readOptionalString(), // monitorId
+        Collections.unmodifiableList(sin.readStringList())
     )
 
+    @Suppress("UNCHECKED_CAST")
     fun asTemplateArg(): Map<String, Any> {
         return mapOf(
             MONITOR_ID_FIELD to monitorId,
-        )
+            MONITOR_IDS_FIELD to monitorIds
+        ) as Map<String, Any>
     }
 
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
-        out.writeString(monitorId)
+        out.writeOptionalString(monitorId)
+        out.writeStringCollection(monitorIds)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(MONITOR_ID_FIELD, monitorId)
+            .field(MONITOR_IDS_FIELD, monitorIds)
             .endObject()
         return builder
     }
 
     companion object {
         const val MONITOR_ID_FIELD = "monitor_id"
+        const val MONITOR_IDS_FIELD = "monitor_ids"
 
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): ChainedMonitorFindings {
-            lateinit var monitorId: String
-
+            var monitorId: String? = null
+            val monitorIds = mutableListOf<String>()
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
                 val fieldName = xcp.currentName()
@@ -60,12 +75,23 @@ data class ChainedMonitorFindings(
 
                 when (fieldName) {
                     MONITOR_ID_FIELD -> {
-                        monitorId = xcp.text()
-                        validateId(monitorId)
+                        if (!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL))
+                            monitorId = xcp.text()
+                    }
+
+                    MONITOR_IDS_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY,
+                            xcp.currentToken(),
+                            xcp
+                        )
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            monitorIds.add(xcp.text())
+                        }
                     }
                 }
             }
-            return ChainedMonitorFindings(monitorId)
+            return ChainedMonitorFindings(monitorId, monitorIds)
         }
 
         @JvmStatic

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -405,6 +405,16 @@ fun randomClusterMetricsInput(
     return ClusterMetricsInput(path, pathParams, url)
 }
 
+fun ChainedMonitorFindings.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
+fun Workflow.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContentWithUser(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
 fun Monitor.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/CompositeInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/CompositeInputTests.kt
@@ -70,9 +70,24 @@ class CompositeInputTests {
     }
 
     @Test
-    fun `test create Chained Findings with illegal monitorId value`() {
+    fun `test create Chained Findings with illegal monitorId value and empty monitorIds list`() {
         try {
             ChainedMonitorFindings("")
+            Assertions.fail("Expecting an illegal argument exception")
+        } catch (e: IllegalArgumentException) {
+            e.message?.let {
+                Assertions.assertTrue(
+                    it.contains("at least one of fields, 'monitorIds' and 'monitorId' should be provided")
+
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `test create Chained Findings with null monitorId value and  monitorIds list with blank monitorIds`() {
+        try {
+            ChainedMonitorFindings("", listOf("", ""))
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             e.message?.let {

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -265,6 +265,30 @@ class XContentTests {
     }
 
     @Test
+    fun `test workflow parsing`() {
+        val workflow = randomWorkflow(monitorIds = listOf("1", "2", "3"))
+        val monitorString = workflow.toJsonString()
+        val parsedWorkflow = Workflow.parse(parser(monitorString))
+        Assertions.assertEquals(workflow, parsedWorkflow, "Round tripping workflow failed")
+    }
+
+    @Test
+    fun `test chainedMonitorFindings parsing`() {
+        val cmf1 = ChainedMonitorFindings(monitorId = "m1")
+        val cmf1String = cmf1.toJsonString()
+        Assertions.assertEquals(
+            ChainedMonitorFindings.parse(parser(cmf1String)), cmf1,
+            "Round tripping chained monitor findings failed"
+        )
+        val cmf2 = ChainedMonitorFindings(monitorIds = listOf("m1", "m2"))
+        val cmf2String = cmf2.toJsonString()
+        Assertions.assertEquals(
+            ChainedMonitorFindings.parse(parser(cmf2String)), cmf2,
+            "Round tripping chained monitor findings failed"
+        )
+    }
+
+    @Test
     fun `test old monitor format parsing`() {
         val monitorString = """
             {


### PR DESCRIPTION
support list of monitor ids in Chained Monitor Findings

Creating manual backport PR as backport CI failed due to conflicts