### PR TITLE
Add User.isAdminDn to User class

### DIFF
--- a/src/main/java/org/opensearch/commons/ConfigConstants.java
+++ b/src/main/java/org/opensearch/commons/ConfigConstants.java
@@ -54,5 +54,7 @@ public class ConfigConstants {
     public static final String INJECTED_USER = "injected_user";
     public static final String OPENSEARCH_SECURITY_USE_INJECTED_USER_FOR_PLUGINS = "plugins.security_use_injected_user_for_plugins";
     public static final String OPENSEARCH_SECURITY_SSL_HTTP_ENABLED = "plugins.security.ssl.http.enabled";
+    public static final String OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN = "plugins.security.authcz.admin_dn";
     public static final String OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT = "_opendistro_security_user_info";
+
 }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -10,6 +10,7 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -19,8 +20,10 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.opensearch.client.Response;
 import org.opensearch.common.Nullable;
 import org.opensearch.common.inject.internal.ToStringBuilder;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.commons.ConfigConstants;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -249,5 +252,10 @@ final public class User implements Writeable, ToXContent {
     @Nullable
     public String getRequestedTenant() {
         return requestedTenant;
+    }
+
+    public static boolean isSuperUser(User user, Settings settings) {
+        List<String> adminDns = settings.getAsList(ConfigConstants.OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList());
+        return adminDns.contains(user.getName());
     }
 }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -255,6 +255,9 @@ final public class User implements Writeable, ToXContent {
     }
 
     public static boolean isSuperUser(User user, Settings settings) {
+        if (user == null || settings == null) {
+            return false;
+        }
         List<String> adminDns = settings.getAsList(ConfigConstants.OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList());
         return adminDns.contains(user.getName());
     }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -254,11 +254,11 @@ final public class User implements Writeable, ToXContent {
         return requestedTenant;
     }
 
-    public static boolean isSuperUser(User user, Settings settings) {
-        if (user == null || settings == null) {
+    public boolean isSuperUser(Settings settings) {
+        if (settings == null) {
             return false;
         }
         List<String> adminDns = settings.getAsList(ConfigConstants.OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN, Collections.emptyList());
-        return adminDns.contains(user.getName());
+        return adminDns.contains(this.name);
     }
 }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -254,7 +254,7 @@ final public class User implements Writeable, ToXContent {
         return requestedTenant;
     }
 
-    public boolean isSuperUser(Settings settings) {
+    public boolean isAdminDn(Settings settings) {
         if (settings == null) {
             return false;
         }

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -206,7 +206,7 @@ public class UserTest {
     }
 
     @Test
-    public void testUserIsSuperUserTrue() {
+    public void testUserIsAdminDnTrue() {
         Settings settings = Settings
             .builder()
             .putList(ConfigConstants.OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN, List.of("CN=kirk,OU=client,O=client,L=test, C=de"))
@@ -219,11 +219,11 @@ public class UserTest {
             );
         String str = tc.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
-        assertTrue(user.isSuperUser(settings));
+        assertTrue(user.isAdminDn(settings));
     }
 
     @Test
-    public void testUserIsSuperUserFalse() {
+    public void testUserIsAdminDnFalse() {
         Settings settings = Settings
             .builder()
             .putList(ConfigConstants.OPENSEARCH_SECURITY_AUTHCZ_ADMIN_DN, List.of("CN=spock,OU=client,O=client,L=test, C=de"))
@@ -236,14 +236,14 @@ public class UserTest {
             );
         String str = tc.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
-        assertFalse(user.isSuperUser(settings));
+        assertFalse(user.isAdminDn(settings));
     }
 
     @Test
     public void testUserOrSettingsAreNullOrEmpty() {
         Settings settings = Settings.EMPTY;
         User user = User.parse("username|backend_role1|role1");
-        assertFalse(user.isSuperUser(null));
-        assertFalse(user.isSuperUser(settings));
+        assertFalse(user.isAdminDn(null));
+        assertFalse(user.isAdminDn(settings));
     }
 }

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -238,4 +238,12 @@ public class UserTest {
         User user = User.parse(str);
         assertFalse(User.isSuperUser(user, settings));
     }
+
+    @Test
+    public void testUserOrSettingsAreNull() {
+        Settings settings = Settings.EMPTY;
+        User user = User.parse("username|backend_role1|role1");
+        assertFalse(User.isSuperUser(null, settings));
+        assertFalse(User.isSuperUser(user, null));
+    }
 }

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -219,7 +219,7 @@ public class UserTest {
             );
         String str = tc.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
-        assertTrue(User.isSuperUser(user, settings));
+        assertTrue(user.isSuperUser(settings));
     }
 
     @Test
@@ -236,14 +236,14 @@ public class UserTest {
             );
         String str = tc.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
-        assertFalse(User.isSuperUser(user, settings));
+        assertFalse(user.isSuperUser(settings));
     }
 
     @Test
-    public void testUserOrSettingsAreNull() {
+    public void testUserOrSettingsAreNullOrEmpty() {
         Settings settings = Settings.EMPTY;
         User user = User.parse("username|backend_role1|role1");
-        assertFalse(User.isSuperUser(null, settings));
-        assertFalse(User.isSuperUser(user, null));
+        assertFalse(user.isSuperUser(null));
+        assertFalse(user.isSuperUser(settings));
     }
 }


### PR DESCRIPTION
### Description

Adds a static helper method on the User class to determine if the user is in the security plugin's `plugins.security.authcz.admin_dn` list.
 
### Issues Resolved

https://github.com/opensearch-project/security/issues/3413
 
### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
