### PR TITLE
add fields param in toxcontent() for doc level query

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -59,6 +59,7 @@ data class DocLevelQuery(
         builder.startObject()
             .field(QUERY_ID_FIELD, id)
             .field(NAME_FIELD, name)
+            .field(FIELDS_FIELD, fields.toTypedArray())
             .field(QUERY_FIELD, query)
             .field(TAGS_FIELD, tags.toTypedArray())
             .endObject()

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -418,6 +418,18 @@ class XContentTests {
     }
 
     @Test
+    fun `test doc level query toXcontent`() {
+        val dlq = DocLevelQuery("id", "name", listOf("f1", "f2"), "query", listOf("t1", "t2"))
+        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
+        Assertions.assertEquals(
+            dlq,
+            parsedDlq,
+            "Round tripping Doc level query doesn't work"
+        )
+    }
+
+    @Test
     fun `test alert parsing`() {
         val alert = randomAlert()
 


### PR DESCRIPTION
### Description
add fields param in toxcontent() for doc level query
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
