### PR TITLE
Move get monitor action / request / response to common-utils

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/AlertingPluginInterface.kt
@@ -17,6 +17,8 @@ import org.opensearch.commons.alerting.action.GetAlertsRequest
 import org.opensearch.commons.alerting.action.GetAlertsResponse
 import org.opensearch.commons.alerting.action.GetFindingsRequest
 import org.opensearch.commons.alerting.action.GetFindingsResponse
+import org.opensearch.commons.alerting.action.GetMonitorRequest
+import org.opensearch.commons.alerting.action.GetMonitorResponse
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsResponse
 import org.opensearch.commons.alerting.action.GetWorkflowRequest
@@ -281,6 +283,30 @@ object AlertingPluginInterface {
             wrapActionListener(listener) { response ->
                 recreateObject(response) {
                     AcknowledgeAlertResponse(
+                        it
+                    )
+                }
+            }
+        )
+    }
+
+    /**
+     * Get Monitor interface.
+     * @param client Node client for making transport action
+     * @param request The request object
+     * @param listener The listener for getting response
+     */
+    fun getMonitor(
+        client: NodeClient,
+        request: GetMonitorRequest,
+        listener: ActionListener<GetMonitorResponse>
+    ) {
+        client.execute(
+            AlertingActions.GET_MONITOR_ACTION_TYPE,
+            request,
+            wrapActionListener(listener) { response ->
+                recreateObject(response) {
+                    GetMonitorResponse(
                         it
                     )
                 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
@@ -18,6 +18,7 @@ object AlertingActions {
     const val ACKNOWLEDGE_ALERTS_ACTION_NAME = "cluster:admin/opendistro/alerting/alerts/ack"
     const val ACKNOWLEDGE_CHAINED_ALERTS_ACTION_NAME = "cluster:admin/opendistro/alerting/chained_alerts/ack"
     const val SUBSCRIBE_FINDINGS_ACTION_NAME = "cluster:admin/opensearch/alerting/findings/subscribe"
+    const val GET_MONITOR_ACTION_NAME = "cluster:admin/opendistro/alerting/monitor/get"
 
     @JvmField
     val INDEX_MONITOR_ACTION_TYPE =
@@ -60,4 +61,8 @@ object AlertingActions {
     @JvmField
     val ACKNOWLEDGE_CHAINED_ALERTS_ACTION_TYPE =
         ActionType(ACKNOWLEDGE_CHAINED_ALERTS_ACTION_NAME, ::AcknowledgeAlertResponse)
+
+    @JvmField
+    val GET_MONITOR_ACTION_TYPE =
+        ActionType(GET_MONITOR_ACTION_NAME, ::GetMonitorResponse)
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.ActionRequestValidationException
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.rest.RestRequest
+import org.opensearch.search.fetch.subphase.FetchSourceContext
+import java.io.IOException
+
+class GetMonitorRequest : ActionRequest {
+    val monitorId: String
+    val version: Long
+    val method: RestRequest.Method
+    val srcContext: FetchSourceContext?
+
+    constructor(
+        monitorId: String,
+        version: Long,
+        method: RestRequest.Method,
+        srcContext: FetchSourceContext?
+    ) : super() {
+        this.monitorId = monitorId
+        this.version = version
+        this.method = method
+        this.srcContext = srcContext
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        sin.readString(), // monitorId
+        sin.readLong(), // version
+        sin.readEnum(RestRequest.Method::class.java), // method
+        if (sin.readBoolean()) {
+            FetchSourceContext(sin) // srcContext
+        } else null
+    )
+
+    override fun validate(): ActionRequestValidationException? {
+        return null
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(monitorId)
+        out.writeLong(version)
+        out.writeEnum(method)
+        out.writeBoolean(srcContext != null)
+        srcContext?.writeTo(out)
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
@@ -10,22 +10,19 @@ import org.opensearch.commons.alerting.util.IndexUtils.Companion._ID
 import org.opensearch.commons.alerting.util.IndexUtils.Companion._PRIMARY_TERM
 import org.opensearch.commons.alerting.util.IndexUtils.Companion._SEQ_NO
 import org.opensearch.commons.alerting.util.IndexUtils.Companion._VERSION
-import org.opensearch.core.action.ActionResponse
+import org.opensearch.commons.notifications.action.BaseResponse
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
-import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.ToXContentFragment
-import org.opensearch.core.xcontent.ToXContentObject
 import org.opensearch.core.xcontent.XContentBuilder
 import java.io.IOException
 
-class GetMonitorResponse : ActionResponse, ToXContentObject {
+class GetMonitorResponse : BaseResponse {
     var id: String
     var version: Long
     var seqNo: Long
     var primaryTerm: Long
-    var status: RestStatus
     var monitor: Monitor?
     var associatedWorkflows: List<AssociatedWorkflow>?
 
@@ -34,7 +31,6 @@ class GetMonitorResponse : ActionResponse, ToXContentObject {
         version: Long,
         seqNo: Long,
         primaryTerm: Long,
-        status: RestStatus,
         monitor: Monitor?,
         associatedCompositeMonitors: List<AssociatedWorkflow>?,
     ) : super() {
@@ -42,7 +38,6 @@ class GetMonitorResponse : ActionResponse, ToXContentObject {
         this.version = version
         this.seqNo = seqNo
         this.primaryTerm = primaryTerm
-        this.status = status
         this.monitor = monitor
         this.associatedWorkflows = associatedCompositeMonitors ?: emptyList()
     }
@@ -53,7 +48,6 @@ class GetMonitorResponse : ActionResponse, ToXContentObject {
         version = sin.readLong(), // version
         seqNo = sin.readLong(), // seqNo
         primaryTerm = sin.readLong(), // primaryTerm
-        status = sin.readEnum(RestStatus::class.java), // RestStatus
         monitor = if (sin.readBoolean()) {
             Monitor.readFrom(sin) // monitor
         } else null,
@@ -66,7 +60,6 @@ class GetMonitorResponse : ActionResponse, ToXContentObject {
         out.writeLong(version)
         out.writeLong(seqNo)
         out.writeLong(primaryTerm)
-        out.writeEnum(status)
         if (monitor != null) {
             out.writeBoolean(true)
             monitor?.writeTo(out)

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.util.IndexUtils.Companion._ID
+import org.opensearch.commons.alerting.util.IndexUtils.Companion._PRIMARY_TERM
+import org.opensearch.commons.alerting.util.IndexUtils.Companion._SEQ_NO
+import org.opensearch.commons.alerting.util.IndexUtils.Companion._VERSION
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentFragment
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import java.io.IOException
+
+class GetMonitorResponse : ActionResponse, ToXContentObject {
+    var id: String
+    var version: Long
+    var seqNo: Long
+    var primaryTerm: Long
+    var status: RestStatus
+    var monitor: Monitor?
+    var associatedWorkflows: List<AssociatedWorkflow>?
+
+    constructor(
+        id: String,
+        version: Long,
+        seqNo: Long,
+        primaryTerm: Long,
+        status: RestStatus,
+        monitor: Monitor?,
+        associatedCompositeMonitors: List<AssociatedWorkflow>?,
+    ) : super() {
+        this.id = id
+        this.version = version
+        this.seqNo = seqNo
+        this.primaryTerm = primaryTerm
+        this.status = status
+        this.monitor = monitor
+        this.associatedWorkflows = associatedCompositeMonitors ?: emptyList()
+    }
+
+    @Throws(IOException::class)
+    constructor(sin: StreamInput) : this(
+        id = sin.readString(), // id
+        version = sin.readLong(), // version
+        seqNo = sin.readLong(), // seqNo
+        primaryTerm = sin.readLong(), // primaryTerm
+        status = sin.readEnum(RestStatus::class.java), // RestStatus
+        monitor = if (sin.readBoolean()) {
+            Monitor.readFrom(sin) // monitor
+        } else null,
+        associatedCompositeMonitors = sin.readList((AssociatedWorkflow)::readFrom),
+    )
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(id)
+        out.writeLong(version)
+        out.writeLong(seqNo)
+        out.writeLong(primaryTerm)
+        out.writeEnum(status)
+        if (monitor != null) {
+            out.writeBoolean(true)
+            monitor?.writeTo(out)
+        } else {
+            out.writeBoolean(false)
+        }
+        associatedWorkflows?.forEach {
+            it.writeTo(out)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+            .field(_ID, id)
+            .field(_VERSION, version)
+            .field(_SEQ_NO, seqNo)
+            .field(_PRIMARY_TERM, primaryTerm)
+        if (monitor != null) {
+            builder.field("monitor", monitor)
+        }
+        if (associatedWorkflows != null) {
+            builder.field("associated_workflows", associatedWorkflows!!.toTypedArray())
+        }
+        return builder.endObject()
+    }
+
+    class AssociatedWorkflow : ToXContentFragment {
+        val id: String
+        val name: String
+
+        constructor(id: String, name: String) {
+            this.id = id
+            this.name = name
+        }
+
+        override fun toXContent(builder: XContentBuilder, params: ToXContent.Params?): XContentBuilder {
+            builder.startObject()
+                .field("id", id)
+                .field("name", name)
+                .endObject()
+            return builder
+        }
+
+        fun writeTo(out: StreamOutput) {
+            out.writeString(id)
+            out.writeString(name)
+        }
+
+        @Throws(IOException::class)
+        constructor(sin: StreamInput) : this(
+            sin.readString(),
+            sin.readString()
+        )
+
+        companion object {
+            @JvmStatic
+            @Throws(IOException::class)
+            fun readFrom(sin: StreamInput): AssociatedWorkflow {
+                return AssociatedWorkflow(sin)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/AlertingPluginInterfaceTests.kt
@@ -23,6 +23,8 @@ import org.opensearch.commons.alerting.action.GetAlertsRequest
 import org.opensearch.commons.alerting.action.GetAlertsResponse
 import org.opensearch.commons.alerting.action.GetFindingsRequest
 import org.opensearch.commons.alerting.action.GetFindingsResponse
+import org.opensearch.commons.alerting.action.GetMonitorRequest
+import org.opensearch.commons.alerting.action.GetMonitorResponse
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsRequest
 import org.opensearch.commons.alerting.action.GetWorkflowAlertsResponse
 import org.opensearch.commons.alerting.action.GetWorkflowRequest
@@ -267,6 +269,20 @@ internal class AlertingPluginInterfaceTests {
                 .onResponse(response)
         }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
         AlertingPluginInterface.acknowledgeChainedAlerts(client, request, listener)
+        Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
+    }
+
+    @Test
+    fun getMonitor() {
+        val request = mock(GetMonitorRequest::class.java)
+        val response = GetMonitorResponse("test-id", 1, 1, 1, null, null)
+        val listener: ActionListener<GetMonitorResponse> =
+            mock(ActionListener::class.java) as ActionListener<GetMonitorResponse>
+        Mockito.doAnswer {
+            (it.getArgument(2) as ActionListener<GetMonitorResponse>)
+                .onResponse(response)
+        }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
+        AlertingPluginInterface.getMonitor(client, request, listener)
         Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequestTests.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.rest.RestRequest
+import org.opensearch.search.fetch.subphase.FetchSourceContext
+import org.opensearch.test.OpenSearchTestCase
+
+class GetMonitorRequestTests : OpenSearchTestCase() {
+
+    fun `test get monitor request`() {
+
+        val req = GetMonitorRequest("1234", 1L, RestRequest.Method.GET, FetchSourceContext.FETCH_SOURCE)
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetMonitorRequest(sin)
+        assertEquals("1234", newReq.monitorId)
+        assertEquals(1L, newReq.version)
+        assertEquals(RestRequest.Method.GET, newReq.method)
+        assertEquals(FetchSourceContext.FETCH_SOURCE, newReq.srcContext)
+    }
+
+    fun `test get monitor request without src context`() {
+
+        val req = GetMonitorRequest("1234", 1L, RestRequest.Method.GET, null)
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetMonitorRequest(sin)
+        assertEquals("1234", newReq.monitorId)
+        assertEquals(1L, newReq.version)
+        assertEquals(RestRequest.Method.GET, newReq.method)
+        assertEquals(null, newReq.srcContext)
+    }
+
+    fun `test head monitor request`() {
+
+        val req = GetMonitorRequest("1234", 2L, RestRequest.Method.HEAD, FetchSourceContext.FETCH_SOURCE)
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetMonitorRequest(sin)
+        assertEquals("1234", newReq.monitorId)
+        assertEquals(2L, newReq.version)
+        assertEquals(RestRequest.Method.HEAD, newReq.method)
+        assertEquals(FetchSourceContext.FETCH_SOURCE, newReq.srcContext)
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponseTests.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.action
+
+import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.commons.alerting.model.CronSchedule
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.commons.alerting.randomUser
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.test.OpenSearchTestCase
+import java.time.Instant
+import java.time.ZoneId
+
+class GetMonitorResponseTests : OpenSearchTestCase() {
+
+    fun `test get monitor response`() {
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, null, null)
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetMonitorResponse(sin)
+        assertEquals("1234", newReq.id)
+        assertEquals(1L, newReq.version)
+        assertEquals(RestStatus.OK, newReq.status)
+        assertEquals(null, newReq.monitor)
+    }
+
+    fun `test get monitor response with monitor`() {
+        val cronExpression = "31 * * * *" // Run at minute 31.
+        val testInstance = Instant.ofEpochSecond(1538164858L)
+
+        val cronSchedule = CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance)
+        val monitor = Monitor(
+            id = "123",
+            version = 0L,
+            name = "test-monitor",
+            enabled = true,
+            schedule = cronSchedule,
+            lastUpdateTime = Instant.now(),
+            enabledTime = Instant.now(),
+            monitorType = Monitor.MonitorType.QUERY_LEVEL_MONITOR,
+            user = randomUser(),
+            schemaVersion = 0,
+            inputs = mutableListOf(),
+            triggers = mutableListOf(),
+            uiMetadata = mutableMapOf()
+        )
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor, null)
+        assertNotNull(req)
+
+        val out = BytesStreamOutput()
+        req.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newReq = GetMonitorResponse(sin)
+        assertEquals("1234", newReq.id)
+        assertEquals(1L, newReq.version)
+        assertEquals(RestStatus.OK, newReq.status)
+        assertNotNull(newReq.monitor)
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponseTests.kt
@@ -10,7 +10,6 @@ import org.opensearch.commons.alerting.model.CronSchedule
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.randomUser
 import org.opensearch.core.common.io.stream.StreamInput
-import org.opensearch.core.rest.RestStatus
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
 import java.time.ZoneId
@@ -18,7 +17,7 @@ import java.time.ZoneId
 class GetMonitorResponseTests : OpenSearchTestCase() {
 
     fun `test get monitor response`() {
-        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, null, null)
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, null, null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -27,7 +26,6 @@ class GetMonitorResponseTests : OpenSearchTestCase() {
         val newReq = GetMonitorResponse(sin)
         assertEquals("1234", newReq.id)
         assertEquals(1L, newReq.version)
-        assertEquals(RestStatus.OK, newReq.status)
         assertEquals(null, newReq.monitor)
     }
 
@@ -51,7 +49,7 @@ class GetMonitorResponseTests : OpenSearchTestCase() {
             triggers = mutableListOf(),
             uiMetadata = mutableMapOf()
         )
-        val req = GetMonitorResponse("1234", 1L, 2L, 0L, RestStatus.OK, monitor, null)
+        val req = GetMonitorResponse("1234", 1L, 2L, 0L, monitor, null)
         assertNotNull(req)
 
         val out = BytesStreamOutput()
@@ -60,7 +58,6 @@ class GetMonitorResponseTests : OpenSearchTestCase() {
         val newReq = GetMonitorResponse(sin)
         assertEquals("1234", newReq.id)
         assertEquals(1L, newReq.version)
-        assertEquals(RestStatus.OK, newReq.status)
         assertNotNull(newReq.monitor)
     }
 }


### PR DESCRIPTION
### Description
Moves get monitor action, request, and response definitions (and all tests) from alerting to this plugin. This is so we can expose get monitor functionality at the transport level using `AlertingPluginInterface`. This follows the same strategy as previous migrations - see #254 as an example.
 
Confirmed the existing tests and added test in `AlertingPluginInterfaceTests` are passing. I've also confirmed this doesn't break functionality when alerting takes a dependency on these changes - there will be a follow up PR in alerting to change the dependencies from the alerting plugin definitions -> common-utils definitions.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
