### PR TITLE
Revert commits dcf288d and d92419d

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -59,7 +59,6 @@ data class DocLevelQuery(
         builder.startObject()
             .field(QUERY_ID_FIELD, id)
             .field(NAME_FIELD, name)
-            .field(FIELDS_FIELD, fields.toTypedArray())
             .field(QUERY_FIELD, query)
             .field(TAGS_FIELD, tags.toTypedArray())
             .endObject()

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -14,7 +14,6 @@ import java.util.UUID
 data class DocLevelQuery(
     val id: String = UUID.randomUUID().toString(),
     val name: String,
-    val fields: List<String>,
     val query: String,
     val tags: List<String> = mutableListOf()
 ) : BaseModel {
@@ -31,7 +30,6 @@ data class DocLevelQuery(
     constructor(sin: StreamInput) : this(
         sin.readString(), // id
         sin.readString(), // name
-        sin.readStringList(), // fields
         sin.readString(), // query
         sin.readStringList() // tags
     )
@@ -40,7 +38,6 @@ data class DocLevelQuery(
         return mapOf(
             QUERY_ID_FIELD to id,
             NAME_FIELD to name,
-            FIELDS_FIELD to fields,
             QUERY_FIELD to query,
             TAGS_FIELD to tags
         )
@@ -50,7 +47,6 @@ data class DocLevelQuery(
     override fun writeTo(out: StreamOutput) {
         out.writeString(id)
         out.writeString(name)
-        out.writeStringCollection(fields)
         out.writeString(query)
         out.writeStringCollection(tags)
     }
@@ -68,7 +64,6 @@ data class DocLevelQuery(
     companion object {
         const val QUERY_ID_FIELD = "id"
         const val NAME_FIELD = "name"
-        const val FIELDS_FIELD = "fields"
         const val QUERY_FIELD = "query"
         const val TAGS_FIELD = "tags"
         const val NO_ID = ""
@@ -81,7 +76,6 @@ data class DocLevelQuery(
             lateinit var query: String
             lateinit var name: String
             val tags: MutableList<String> = mutableListOf()
-            val fields: MutableList<String> = mutableListOf()
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -107,24 +101,12 @@ data class DocLevelQuery(
                             tags.add(tag)
                         }
                     }
-                    FIELDS_FIELD -> {
-                        XContentParserUtils.ensureExpectedToken(
-                            XContentParser.Token.START_ARRAY,
-                            xcp.currentToken(),
-                            xcp
-                        )
-                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
-                            val field = xcp.text()
-                            fields.add(field)
-                        }
-                    }
                 }
             }
 
             return DocLevelQuery(
                 id = id,
                 name = name,
-                fields = fields,
                 query = query,
                 tags = tags
             )

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -383,7 +383,7 @@ fun randomDocLevelQuery(
     name: String = "${RandomNumbers.randomIntBetween(Random(), 0, 5)}",
     tags: List<String> = mutableListOf(0..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { RandomStrings.randomAsciiLettersOfLength(Random(), 10) }
 ): DocLevelQuery {
-    return DocLevelQuery(id = id, query = query, name = name, tags = tags, fields = listOf("*"))
+    return DocLevelQuery(id = id, query = query, name = name, tags = tags)
 }
 
 fun randomDocLevelMonitorInput(

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsResponseTests.kt
@@ -24,7 +24,7 @@ internal class GetFindingsResponseTests {
             "monitor_id1",
             "monitor_name1",
             "test_index1",
-            listOf(DocLevelQuery("1", "myQuery", listOf(), "fieldA:valABC", listOf())),
+            listOf(DocLevelQuery("1", "myQuery", "fieldA:valABC", listOf())),
             Instant.now()
         )
         val findingDocument1 = FindingDocument("test_index1", "doc1", true, "document 1 payload")
@@ -43,7 +43,7 @@ internal class GetFindingsResponseTests {
             "monitor_id2",
             "monitor_name2",
             "test_index2",
-            listOf(DocLevelQuery("1", "myQuery", listOf(), "fieldA:valABC", listOf())),
+            listOf(DocLevelQuery("1", "myQuery", "fieldA:valABC", listOf())),
             Instant.now()
         )
         val findingDocument21 = FindingDocument("test_index2", "doc21", true, "document 21 payload")

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -10,7 +10,6 @@ import org.opensearch.commons.alerting.randomAction
 import org.opensearch.commons.alerting.randomActionExecutionPolicy
 import org.opensearch.commons.alerting.randomBucketLevelTrigger
 import org.opensearch.commons.alerting.randomChainedAlertTrigger
-import org.opensearch.commons.alerting.randomDocLevelQuery
 import org.opensearch.commons.alerting.randomDocumentLevelTrigger
 import org.opensearch.commons.alerting.randomQueryLevelMonitor
 import org.opensearch.commons.alerting.randomQueryLevelTrigger
@@ -111,16 +110,6 @@ class WriteableTests {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newTrigger = DocumentLevelTrigger.readFrom(sin)
         Assertions.assertEquals(trigger, newTrigger, "Round tripping DocumentLevelTrigger doesn't work")
-    }
-
-    @Test
-    fun `test doc-level query as stream`() {
-        val dlq = randomDocLevelQuery()
-        val out = BytesStreamOutput()
-        dlq.writeTo(out)
-        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
-        val newDlq = DocLevelQuery.readFrom(sin)
-        Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
     }
 
     @Test

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -418,18 +418,6 @@ class XContentTests {
     }
 
     @Test
-    fun `test doc level query toXcontent`() {
-        val dlq = DocLevelQuery("id", "name", listOf("f1", "f2"), "query", listOf("t1", "t2"))
-        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
-        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
-        Assertions.assertEquals(
-            dlq,
-            parsedDlq,
-            "Round tripping Doc level query doesn't work"
-        )
-    }
-
-    @Test
     fun `test alert parsing`() {
         val alert = randomAlert()
 


### PR DESCRIPTION
### Description
Revert commits dcf288d and d92419d related to adding fields param in DocLevelQuery object.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
