### PR TITLE
Add condition to the templateArg of BucketLevelTrigger

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/BucketLevelTrigger.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/BucketLevelTrigger.kt
@@ -69,12 +69,17 @@ data class BucketLevelTrigger(
             NAME_FIELD to name,
             SEVERITY_FIELD to severity,
             ACTIONS_FIELD to actions.map { it.asTemplateArg() },
-            PARENT_BUCKET_PATH to getParentBucketPath()
+            PARENT_BUCKET_PATH to getParentBucketPath(),
+            CONDITION_FIELD to getCondition()
         )
     }
 
     fun getParentBucketPath(): String {
         return bucketSelector.parentBucketPath
+    }
+
+    fun getCondition(): String {
+        return bucketSelector.script.idOrCode
     }
 
     companion object {

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
@@ -1,6 +1,6 @@
-package org.opensearch.commons.alerting.model;
+package org.opensearch.commons.alerting.model
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test
 import org.opensearch.commons.alerting.randomBucketLevelTrigger
 import kotlin.test.assertEquals
 
@@ -10,7 +10,6 @@ class BucketLevelTriggerTests {
     fun `test asTemplateArgs returns expected values`() {
         val bucketLevelTrigger = randomBucketLevelTrigger()
         val templateArg = bucketLevelTrigger.asTemplateArg()
-        System.out.println(templateArg)
 
         assertEquals(templateArg[Trigger.ID_FIELD], bucketLevelTrigger.id)
         assertEquals(templateArg[Trigger.NAME_FIELD], bucketLevelTrigger.name)

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
@@ -1,0 +1,22 @@
+package org.opensearch.commons.alerting.model;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.commons.alerting.randomBucketLevelTrigger
+import kotlin.test.assertEquals
+
+class BucketLevelTriggerTests {
+
+    @Test
+    fun `test asTemplateArgs returns expected values`() {
+        val bucketLevelTrigger = randomBucketLevelTrigger()
+        val templateArg = bucketLevelTrigger.asTemplateArg()
+        System.out.println(templateArg)
+
+        assertEquals(templateArg[Trigger.ID_FIELD], bucketLevelTrigger.id)
+        assertEquals(templateArg[Trigger.NAME_FIELD], bucketLevelTrigger.name)
+        assertEquals(templateArg[Trigger.SEVERITY_FIELD], bucketLevelTrigger.severity)
+        assertEquals(templateArg[Trigger.ACTIONS_FIELD], bucketLevelTrigger.actions.map { it.asTemplateArg() })
+        assertEquals(templateArg[BucketLevelTrigger.PARENT_BUCKET_PATH], bucketLevelTrigger.bucketSelector.parentBucketPath)
+        assertEquals(templateArg[BucketLevelTrigger.CONDITION_FIELD], bucketLevelTrigger.bucketSelector.script.idOrCode)
+    }
+}


### PR DESCRIPTION
### Description
Adds the condition to the BucketLevelTrigger templateArg so that it can be consumed in notifications

ctx.trigger before this change:
```
{
    id=0tgobIwBxdVVQaI5AhDn,
    name=mytrigger,
    severity=1,
    actions=[
        {
            name=myaction
        }
    ],
    parentBucketPath=versions
}
```

ctx.trigger after this change:
```
{
    id=0tgobIwBxdVVQaI5AhDn,
    name=mytrigger,
    severity=1,
    actions=[
        {
            name=myaction
        }
    ],
    parentBucketPath=versions,
    condition=params.cpu_avg > 0
}
```
 
### Issues Resolved
https://github.com/opensearch-project/alerting/issues/1299
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
