### PR TITLE
changed all usages of 'admin' as a password to something different

### DIFF
--- a/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
+++ b/src/main/java/org/opensearch/commons/rest/SecureRestClientBuilder.java
@@ -54,7 +54,7 @@ import org.opensearch.core.common.Strings;
  *
  * Other usage:
  *  RestClient restClient = new SecureRestClientBuilder("localhost", 9200, false)
- *                     .setUserPassword("admin", "admin")
+ *                     .setUserPassword("admin", "myStrongPassword123")
  *                     .setTrustCerts(trustStorePath)
  *                     .build();
  *

--- a/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
+++ b/src/test/java/org/opensearch/commons/rest/IntegrationTests.java
@@ -47,7 +47,7 @@ public class IntegrationTests {
 
     @Test
     public void testCreateRestClientWithUser() throws Exception {
-        RestClient client = new SecureRestClientBuilder("localhost", 9200, true, "admin", "admin").build();
+        RestClient client = new SecureRestClientBuilder("localhost", 9200, true, "admin", "myStrongPassword123").build();
         Response response = client.performRequest(createSampleRequest());
         String responseBody = EntityUtils.toString(response.getEntity());
         assertEquals(200, response.getStatusLine().getStatusCode());


### PR DESCRIPTION
### Description
These changes stop common-utils from using 'admin' as a password in any security plugin related workflows
 
### Issues Resolved
https://github.com/opensearch-project/common-utils/issues/579
 
### Check List
- [N] New functionality includes testing.
  - [Y] All tests pass
- [N] New functionality has been documented.
  - [N/A] New functionality has javadoc added
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
