### PR TITLE
add queryFieldNames field in Doc Level Queries

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -17,7 +17,7 @@ data class DocLevelQuery(
     val fields: List<String>,
     val query: String,
     val tags: List<String> = mutableListOf(),
-    val queryFieldNames: List<String> = mutableListOf(),
+    val queryFieldNames: List<String> = mutableListOf()
 ) : BaseModel {
 
     init {
@@ -177,7 +177,7 @@ data class DocLevelQuery(
         name: String,
         fields: MutableList<String>,
         query: String,
-        tags: MutableList<String>,
+        tags: MutableList<String>
     ) : this(
         id = id,
         name = name,

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -16,7 +16,8 @@ data class DocLevelQuery(
     val name: String,
     val fields: List<String>,
     val query: String,
-    val tags: List<String> = mutableListOf()
+    val tags: List<String> = mutableListOf(),
+    val queryFieldNames: List<String> = mutableListOf(),
 ) : BaseModel {
 
     init {
@@ -33,7 +34,8 @@ data class DocLevelQuery(
         sin.readString(), // name
         sin.readStringList(), // fields
         sin.readString(), // query
-        sin.readStringList() // tags
+        sin.readStringList(), // tags,
+        sin.readStringList() // fieldsBeingQueried
     )
 
     fun asTemplateArg(): Map<String, Any> {
@@ -42,7 +44,8 @@ data class DocLevelQuery(
             NAME_FIELD to name,
             FIELDS_FIELD to fields,
             QUERY_FIELD to query,
-            TAGS_FIELD to tags
+            TAGS_FIELD to tags,
+            QUERY_FIELD_NAMES_FIELD to queryFieldNames
         )
     }
 
@@ -53,6 +56,7 @@ data class DocLevelQuery(
         out.writeStringCollection(fields)
         out.writeString(query)
         out.writeStringCollection(tags)
+        out.writeStringCollection(queryFieldNames)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -62,6 +66,7 @@ data class DocLevelQuery(
             .field(FIELDS_FIELD, fields.toTypedArray())
             .field(QUERY_FIELD, query)
             .field(TAGS_FIELD, tags.toTypedArray())
+            .field(QUERY_FIELD_NAMES_FIELD, queryFieldNames.toTypedArray())
             .endObject()
         return builder
     }
@@ -72,6 +77,7 @@ data class DocLevelQuery(
         const val FIELDS_FIELD = "fields"
         const val QUERY_FIELD = "query"
         const val TAGS_FIELD = "tags"
+        const val QUERY_FIELD_NAMES_FIELD = "query_field_names"
         const val NO_ID = ""
         val INVALID_CHARACTERS: List<String> = listOf(" ", "[", "]", "{", "}", "(", ")")
 
@@ -83,6 +89,7 @@ data class DocLevelQuery(
             lateinit var name: String
             val tags: MutableList<String> = mutableListOf()
             val fields: MutableList<String> = mutableListOf()
+            val queryFieldNames: MutableList<String> = mutableListOf()
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -95,6 +102,7 @@ data class DocLevelQuery(
                         name = xcp.text()
                         validateQuery(name)
                     }
+
                     QUERY_FIELD -> query = xcp.text()
                     TAGS_FIELD -> {
                         XContentParserUtils.ensureExpectedToken(
@@ -108,6 +116,7 @@ data class DocLevelQuery(
                             tags.add(tag)
                         }
                     }
+
                     FIELDS_FIELD -> {
                         XContentParserUtils.ensureExpectedToken(
                             XContentParser.Token.START_ARRAY,
@@ -119,6 +128,18 @@ data class DocLevelQuery(
                             fields.add(field)
                         }
                     }
+
+                    QUERY_FIELD_NAMES_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY,
+                            xcp.currentToken(),
+                            xcp
+                        )
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            val field = xcp.text()
+                            queryFieldNames.add(field)
+                        }
+                    }
                 }
             }
 
@@ -127,7 +148,8 @@ data class DocLevelQuery(
                 name = name,
                 fields = fields,
                 query = query,
-                tags = tags
+                tags = tags,
+                queryFieldNames = queryFieldNames
             )
         }
 
@@ -148,4 +170,20 @@ data class DocLevelQuery(
             }
         }
     }
+
+    // constructor for java plugins' convenience to optionally avoid passing empty list for 'fieldsBeingQueried' field
+    constructor(
+        id: String,
+        name: String,
+        fields: MutableList<String>,
+        query: String,
+        tags: MutableList<String>,
+    ) : this(
+        id = id,
+        name = name,
+        fields = fields,
+        query = query,
+        tags = tags,
+        queryFieldNames = emptyList()
+    )
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -21,6 +21,7 @@ import org.opensearch.commons.alerting.randomWorkflow
 import org.opensearch.commons.authuser.User
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.search.builder.SearchSourceBuilder
+import kotlin.test.assertTrue
 
 class WriteableTests {
 
@@ -131,6 +132,19 @@ class WriteableTests {
         dlq.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newDlq = DocLevelQuery.readFrom(sin)
+        Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
+        assertTrue(newDlq.queryFieldNames.isEmpty())
+    }
+
+    @Test
+    fun `test doc-level query with query Field Names as stream`() {
+        val dlq = randomDocLevelQuery().copy(queryFieldNames = listOf("f1", "f2"))
+        val out = BytesStreamOutput()
+        dlq.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newDlq = DocLevelQuery.readFrom(sin)
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[0]))
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[1]))
         Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
     }
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -432,6 +432,18 @@ class XContentTests {
     }
 
     @Test
+    fun `test doc level query toXcontent with query field names`() {
+        val dlq = DocLevelQuery("id", "name", listOf("f1", "f2"), "query", listOf("t1", "t2"), listOf("f1", "f2"))
+        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
+        Assertions.assertEquals(
+            dlq,
+            parsedDlq,
+            "Round tripping Doc level query doesn't work"
+        )
+    }
+
+    @Test
     fun `test alert parsing`() {
         val alert = randomAlert()
 


### PR DESCRIPTION
add queryFieldNames field in Doc Level Queries. When specified this field gives the list of fields to query and fetch from all docs to be searched in the index as opposed to fetching entire `_source` of each document.

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
