### PR TITLE
[Backport 2.x] Update dependency com.pinterest:ktlint to 0.47.1 and fix CVE-2023-6378 for common-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation "commons-validator:commons-validator:1.7"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 
-    ktlint "com.pinterest:ktlint:0.44.0"
+    ktlint "com.pinterest:ktlint:0.47.1"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,12 @@ apply plugin: 'opensearch.repositories'
 apply from: 'build-tools/opensearchplugin-coverage.gradle'
 
 configurations {
-    ktlint
+    ktlint {
+      resolutionStrategy {
+          force "ch.qos.logback:logback-classic:1.3.14"
+          force "ch.qos.logback:logback-core:1.3.14"
+      }
+   }
 }
 
 dependencies {

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeChainedAlertRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeChainedAlertRequest.kt
@@ -19,7 +19,7 @@ class AcknowledgeChainedAlertRequest : ActionRequest {
 
     constructor(
         workflowId: String,
-        alertIds: List<String>,
+        alertIds: List<String>
     ) : super() {
         this.workflowId = workflowId
         this.alertIds = alertIds
@@ -28,7 +28,7 @@ class AcknowledgeChainedAlertRequest : ActionRequest {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         sin.readString(), // workflowId
-        Collections.unmodifiableList(sin.readStringList()), // alertIds
+        Collections.unmodifiableList(sin.readStringList()) // alertIds
     )
 
     override fun validate(): ActionRequestValidationException? {

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
@@ -29,6 +29,7 @@ object AlertingActions {
     @JvmField
     val INDEX_WORKFLOW_ACTION_TYPE =
         ActionType(INDEX_WORKFLOW_ACTION_NAME, ::IndexWorkflowResponse)
+
     @JvmField
     val GET_ALERTS_ACTION_TYPE =
         ActionType(GET_ALERTS_ACTION_NAME, ::GetAlertsResponse)
@@ -48,6 +49,7 @@ object AlertingActions {
     @JvmField
     val DELETE_WORKFLOW_ACTION_TYPE =
         ActionType(DELETE_WORKFLOW_ACTION_NAME, ::DeleteWorkflowResponse)
+
     @JvmField
     val GET_FINDINGS_ACTION_TYPE =
         ActionType(GET_FINDINGS_ACTION_NAME, ::GetFindingsResponse)

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequest.kt
@@ -9,6 +9,7 @@ import java.io.IOException
 class DeleteWorkflowRequest : ActionRequest {
 
     val workflowId: String
+
     /**
      * Flag that indicates whether the delegate monitors should be deleted or not.
      * If the flag is set to true, Delegate monitors will be deleted only in the case when they are part of the specified workflow and no other.

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
@@ -38,7 +38,9 @@ class GetMonitorRequest : ActionRequest {
         sin.readEnum(RestRequest.Method::class.java), // method
         if (sin.readBoolean()) {
             FetchSourceContext(sin) // srcContext
-        } else null
+        } else {
+            null
+        }
     )
 
     override fun validate(): ActionRequestValidationException? {

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorResponse.kt
@@ -32,7 +32,7 @@ class GetMonitorResponse : BaseResponse {
         seqNo: Long,
         primaryTerm: Long,
         monitor: Monitor?,
-        associatedCompositeMonitors: List<AssociatedWorkflow>?,
+        associatedCompositeMonitors: List<AssociatedWorkflow>?
     ) : super() {
         this.id = id
         this.version = version
@@ -50,8 +50,10 @@ class GetMonitorResponse : BaseResponse {
         primaryTerm = sin.readLong(), // primaryTerm
         monitor = if (sin.readBoolean()) {
             Monitor.readFrom(sin) // monitor
-        } else null,
-        associatedCompositeMonitors = sin.readList((AssociatedWorkflow)::readFrom),
+        } else {
+            null
+        },
+        associatedCompositeMonitors = sin.readList((AssociatedWorkflow)::readFrom)
     )
 
     @Throws(IOException::class)

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequest.kt
@@ -27,7 +27,7 @@ class GetWorkflowAlertsRequest : ActionRequest {
         monitorIds: List<String>? = null,
         workflowIds: List<String>? = null,
         alertIds: List<String>? = null,
-        getAssociatedAlerts: Boolean,
+        getAssociatedAlerts: Boolean
     ) : super() {
         this.table = table
         this.severityLevel = severityLevel

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsResponse.kt
@@ -12,6 +12,7 @@ import java.util.Collections
 class GetWorkflowAlertsResponse : BaseResponse {
     val alerts: List<Alert>
     val associatedAlerts: List<Alert>
+
     // totalAlerts is not the same as the size of alerts because there can be 30 alerts from the request, but
     // the request only asked for 5 alerts, so totalAlerts will be 30, but alerts will only contain 5 alerts
     val totalAlerts: Int?

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowResponse.kt
@@ -51,7 +51,9 @@ class GetWorkflowResponse : BaseResponse {
         sin.readEnum(RestStatus::class.java), // RestStatus
         if (sin.readBoolean()) {
             Workflow.readFrom(sin) // monitor
-        } else null
+        } else {
+            null
+        }
     )
 
     @Throws(IOException::class)
@@ -76,8 +78,9 @@ class GetWorkflowResponse : BaseResponse {
             .field(_VERSION, version)
             .field(_SEQ_NO, seqNo)
             .field(_PRIMARY_TERM, primaryTerm)
-        if (workflow != null)
+        if (workflow != null) {
             builder.field("workflow", workflow)
+        }
 
         return builder.endObject()
     }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
@@ -57,19 +57,22 @@ class IndexWorkflowRequest : ActionRequest {
 
         if (workflow.inputs.isEmpty()) {
             validationException = ValidateActions.addValidationError(
-                "Input list can not be empty.", validationException
+                "Input list can not be empty.",
+                validationException
             )
             return validationException
         }
         if (workflow.inputs.size > 1) {
             validationException = ValidateActions.addValidationError(
-                "Input list can contain only one element.", validationException
+                "Input list can contain only one element.",
+                validationException
             )
             return validationException
         }
         if (workflow.inputs[0] !is CompositeInput) {
             validationException = ValidateActions.addValidationError(
-                "When creating a workflow input must be CompositeInput", validationException
+                "When creating a workflow input must be CompositeInput",
+                validationException
             )
         }
         val compositeInput = workflow.inputs[0] as CompositeInput
@@ -77,7 +80,8 @@ class IndexWorkflowRequest : ActionRequest {
 
         if (monitorIds.isNullOrEmpty()) {
             validationException = ValidateActions.addValidationError(
-                "Delegates list can not be empty.", validationException
+                "Delegates list can not be empty.",
+                validationException
             )
             // Break the flow because next checks are dependant on non-null monitorIds
             return validationException
@@ -85,27 +89,29 @@ class IndexWorkflowRequest : ActionRequest {
 
         if (monitorIds.size > MAX_DELEGATE_SIZE) {
             validationException = ValidateActions.addValidationError(
-                "Delegates list can not be larger then $MAX_DELEGATE_SIZE.", validationException
+                "Delegates list can not be larger then $MAX_DELEGATE_SIZE.",
+                validationException
             )
         }
 
         if (monitorIds.toSet().size != monitorIds.size) {
             validationException = ValidateActions.addValidationError(
-                "Duplicate delegates not allowed", validationException
+                "Duplicate delegates not allowed",
+                validationException
             )
         }
         val delegates = compositeInput.sequence.delegates
         val orderSet = delegates.stream().filter { it.order > 0 }.map { it.order }.collect(Collectors.toSet())
         if (orderSet.size != delegates.size) {
             validationException = ValidateActions.addValidationError(
-                "Sequence ordering of delegate monitor shouldn't contain duplicate order values", validationException
+                "Sequence ordering of delegate monitor shouldn't contain duplicate order values",
+                validationException
             )
         }
 
         val monitorIdOrderMap: Map<String, Int> = delegates.associate { it.monitorId to it.order }
         delegates.forEach {
             if (it.chainedMonitorFindings != null) {
-
                 if (it.chainedMonitorFindings.monitorId != null) {
                     if (monitorIdOrderMap.containsKey(it.chainedMonitorFindings.monitorId) == false) {
                         validationException = ValidateActions.addValidationError(

--- a/src/main/kotlin/org/opensearch/commons/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregator.kt
@@ -33,7 +33,7 @@ class BucketSelectorExtAggregator : SiblingPipelineAggregator {
         script: Script,
         gapPolicy: BucketHelpers.GapPolicy,
         filter: BucketSelectorExtFilter?,
-        metadata: Map<String, Any>?,
+        metadata: Map<String, Any>?
     ) : super(name, bucketsPathsMap.values.toTypedArray(), metadata) {
         this.bucketsPathsMap = bucketsPathsMap
         this.parentBucketPath = parentBucketPath
@@ -132,7 +132,7 @@ class BucketSelectorExtAggregator : SiblingPipelineAggregator {
             name(),
             parentBucketPath,
             selectedBucketsIndex,
-            originalAgg.metadata,
+            originalAgg.metadata
         )
     }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
@@ -43,12 +43,14 @@ data class Alert(
     val aggregationResultBucket: AggregationResultBucket? = null,
     val executionId: String? = null,
     val associatedAlertIds: List<String>,
-    val clusters: List<String>? = null,
+    val clusters: List<String>? = null
 ) : Writeable, ToXContent {
 
     init {
-        if (errorMessage != null) require(state == State.DELETED || state == State.ERROR || state == State.AUDIT) {
-            "Attempt to create an alert with an error in state: $state"
+        if (errorMessage != null) {
+            require(state == State.DELETED || state == State.ERROR || state == State.AUDIT) {
+                "Attempt to create an alert with an error in state: $state"
+            }
         }
     }
 
@@ -308,7 +310,9 @@ data class Alert(
         monitorVersion = sin.readLong(),
         monitorUser = if (sin.readBoolean()) {
             User(sin)
-        } else null,
+        } else {
+            null
+        },
         triggerId = sin.readString(),
         triggerName = sin.readString(),
         findingIds = sin.readStringList(),
@@ -439,8 +443,11 @@ data class Alert(
                     MONITOR_NAME_FIELD -> monitorName = xcp.text()
                     MONITOR_VERSION_FIELD -> monitorVersion = xcp.longValue()
                     MONITOR_USER_FIELD ->
-                        monitorUser = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null
-                        else User.parse(xcp)
+                        monitorUser = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            null
+                        } else {
+                            User.parse(xcp)
+                        }
                     TRIGGER_ID_FIELD -> triggerId = xcp.text()
                     FINDING_IDS -> {
                         ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ChainedMonitorFindings.kt
@@ -17,7 +17,7 @@ import java.util.Collections
 // TODO - Remove the class and move the monitorId to Delegate (as a chainedMonitorId property) if this class won't be updated by adding new properties
 data class ChainedMonitorFindings(
     val monitorId: String? = null,
-    val monitorIds: List<String> = emptyList(), // if monitorId field is non-null it would be given precendence for BWC
+    val monitorIds: List<String> = emptyList() // if monitorId field is non-null it would be given precendence for BWC
 ) : BaseModel {
 
     init {
@@ -75,8 +75,9 @@ data class ChainedMonitorFindings(
 
                 when (fieldName) {
                     MONITOR_ID_FIELD -> {
-                        if (!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL))
+                        if (!xcp.currentToken().equals(XContentParser.Token.VALUE_NULL)) {
                             monitorId = xcp.text()
+                        }
                     }
 
                     MONITOR_IDS_FIELD -> {

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -45,10 +45,11 @@ data class ClusterMetricsInput(
             "Invalid URI constructed from the path and path_params inputs, or the url input."
         }
 
-        if (url.isNotEmpty() && validateFieldsNotEmpty())
+        if (url.isNotEmpty() && validateFieldsNotEmpty()) {
             require(constructedUri == constructUrlFromInputs()) {
                 "The provided URL and URI fields form different URLs."
             }
+        }
 
         require(constructedUri.host.lowercase() == SUPPORTED_HOST) {
             "Only host '$SUPPORTED_HOST' is supported."
@@ -109,7 +110,8 @@ data class ClusterMetricsInput(
         /**
          * This parse function uses [XContentParser] to parse JSON input and store corresponding fields to create a [ClusterMetricsInput] object
          */
-        @JvmStatic @Throws(IOException::class)
+        @JvmStatic
+        @Throws(IOException::class)
         fun parseInner(xcp: XContentParser): ClusterMetricsInput {
             var path = ""
             var pathParams = ""
@@ -175,17 +177,20 @@ data class ClusterMetricsInput(
         if (pathParams.isNotEmpty()) {
             pathParams = pathParams.trim('/')
             ILLEGAL_PATH_PARAMETER_CHARACTERS.forEach { character ->
-                if (pathParams.contains(character))
+                if (pathParams.contains(character)) {
                     throw IllegalArgumentException(
                         "The provided path parameters contain invalid characters or spaces. Please omit: " + ILLEGAL_PATH_PARAMETER_CHARACTERS.joinToString(" ")
                     )
+                }
             }
         }
 
-        if (apiType.requiresPathParams && pathParams.isEmpty())
+        if (apiType.requiresPathParams && pathParams.isEmpty()) {
             throw IllegalArgumentException("The API requires path parameters.")
-        if (!apiType.supportsPathParams && pathParams.isNotEmpty())
+        }
+        if (!apiType.supportsPathParams && pathParams.isNotEmpty()) {
             throw IllegalArgumentException("The API does not use path parameters.")
+        }
 
         return pathParams
     }
@@ -201,11 +206,13 @@ data class ClusterMetricsInput(
         ClusterMetricType.values()
             .filter { option -> option != ClusterMetricType.BLANK }
             .forEach { option ->
-                if (uriPath.startsWith(option.prependPath) || uriPath.startsWith(option.defaultPath))
+                if (uriPath.startsWith(option.prependPath) || uriPath.startsWith(option.defaultPath)) {
                     apiType = option
+                }
             }
-        if (apiType.isBlank())
+        if (apiType.isBlank()) {
             throw IllegalArgumentException("The API could not be determined from the provided URI.")
+        }
         return apiType
     }
 
@@ -238,12 +245,15 @@ data class ClusterMetricsInput(
      * If [path] and [pathParams] are empty, populates them with values from [url].
      */
     private fun parseEmptyFields() {
-        if (pathParams.isEmpty())
+        if (pathParams.isEmpty()) {
             pathParams = this.parsePathParams()
-        if (path.isEmpty())
+        }
+        if (path.isEmpty()) {
             path = if (pathParams.isEmpty()) clusterMetricType.defaultPath else clusterMetricType.prependPath
-        if (url.isEmpty())
+        }
+        if (url.isEmpty()) {
             url = constructedUri.toString()
+        }
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/CompositeInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/CompositeInput.kt
@@ -12,7 +12,7 @@ import org.opensearch.core.xcontent.XContentParserUtils
 import java.io.IOException
 
 data class CompositeInput(
-    val sequence: Sequence,
+    val sequence: Sequence
 ) : WorkflowInput {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
@@ -53,7 +53,8 @@ data class CompositeInput(
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
             WorkflowInput::class.java,
-            ParseField(COMPOSITE_INPUT_FIELD), CheckedFunction { CompositeInput.parse(it) }
+            ParseField(COMPOSITE_INPUT_FIELD),
+            CheckedFunction { CompositeInput.parse(it) }
         )
 
         @JvmStatic

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Delegate.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Delegate.kt
@@ -42,13 +42,15 @@ data class Delegate(
         monitorId = sin.readString(),
         chainedMonitorFindings = if (sin.readBoolean()) {
             ChainedMonitorFindings(sin)
-        } else null,
+        } else {
+            null
+        }
     )
 
     fun asTemplateArg(): Map<String, Any> {
         return mapOf(
             ORDER_FIELD to order,
-            MONITOR_ID_FIELD to monitorId,
+            MONITOR_ID_FIELD to monitorId
         )
     }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Finding.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Finding.kt
@@ -27,7 +27,7 @@ class Finding(
      * Keeps the track of the workflow-monitor exact execution.
      * Used for filtering the data when chaining monitors in a workflow.
      */
-    val executionId: String? = null,
+    val executionId: String? = null
 ) : Writeable, ToXContent {
 
     constructor(

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -97,7 +97,9 @@ data class Monitor(
         monitorType = sin.readEnum(MonitorType::class.java),
         user = if (sin.readBoolean()) {
             User(sin)
-        } else null,
+        } else {
+            null
+        },
         schemaVersion = sin.readInt(),
         inputs = sin.readList((Input)::readFrom),
         triggers = sin.readList((Trigger)::readFrom),
@@ -184,8 +186,11 @@ data class Monitor(
         // Outputting type with each Input so that the generic Input.readFrom() can read it
         out.writeVInt(inputs.size)
         inputs.forEach {
-            if (it is SearchInput) out.writeEnum(Input.Type.SEARCH_INPUT)
-            else out.writeEnum(Input.Type.DOCUMENT_LEVEL_INPUT)
+            if (it is SearchInput) {
+                out.writeEnum(Input.Type.SEARCH_INPUT)
+            } else {
+                out.writeEnum(Input.Type.DOCUMENT_LEVEL_INPUT)
+            }
             it.writeTo(out)
         }
         // Outputting type with each Trigger so that the generic Trigger.readFrom() can read it
@@ -295,8 +300,11 @@ data class Monitor(
                     ENABLED_TIME_FIELD -> enabledTime = xcp.instant()
                     LAST_UPDATE_TIME_FIELD -> lastUpdateTime = xcp.instant()
                     UI_METADATA_FIELD -> uiMetadata = xcp.map()
-                    DATA_SOURCES_FIELD -> dataSources = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) DataSources()
-                    else DataSources.parse(xcp)
+                    DATA_SOURCES_FIELD -> dataSources = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        DataSources()
+                    } else {
+                        DataSources.parse(xcp)
+                    }
                     OWNER_FIELD -> owner = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) owner else xcp.text()
                     else -> {
                         xcp.skipChildren()

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/NoOpTrigger.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/NoOpTrigger.kt
@@ -17,7 +17,7 @@ data class NoOpTrigger(
     override val id: String = UUIDs.base64UUID(),
     override val name: String = "NoOp trigger",
     override val severity: String = "",
-    override val actions: List<Action> = listOf(),
+    override val actions: List<Action> = listOf()
 ) : Trigger {
 
     @Throws(IOException::class)
@@ -48,11 +48,13 @@ data class NoOpTrigger(
         const val ID_FIELD = "id"
         const val NOOP_TRIGGER_FIELD = "noop_trigger"
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
-            Trigger::class.java, ParseField(NOOP_TRIGGER_FIELD),
+            Trigger::class.java,
+            ParseField(NOOP_TRIGGER_FIELD),
             CheckedFunction { parseInner(it) }
         )
 
-        @JvmStatic @Throws(IOException::class)
+        @JvmStatic
+        @Throws(IOException::class)
         fun parseInner(xcp: XContentParser): NoOpTrigger {
             var id = UUIDs.base64UUID()
             if (xcp.currentToken() == XContentParser.Token.START_OBJECT) xcp.nextToken()

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Sequence.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Sequence.kt
@@ -21,7 +21,7 @@ data class Sequence(
 
     fun asTemplateArg(): Map<String, Any?> {
         return mapOf(
-            DELEGATES_FIELD to delegates,
+            DELEGATES_FIELD to delegates
         )
     }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Workflow.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Workflow.kt
@@ -37,7 +37,7 @@ data class Workflow(
     val inputs: List<WorkflowInput>,
     val owner: String? = DEFAULT_OWNER,
     val triggers: List<Trigger>,
-    val auditDelegateMonitorAlerts: Boolean? = true,
+    val auditDelegateMonitorAlerts: Boolean? = true
 ) : ScheduledJob {
     override val type = WORKFLOW_TYPE
 
@@ -67,7 +67,9 @@ data class Workflow(
         workflowType = sin.readEnum(WorkflowType::class.java),
         user = if (sin.readBoolean()) {
             User(sin)
-        } else null,
+        } else {
+            null
+        },
         schemaVersion = sin.readInt(),
         inputs = sin.readList((WorkflowInput)::readFrom),
         owner = sin.readOptionalString(),
@@ -101,7 +103,7 @@ data class Workflow(
     private fun createXContentBuilder(
         builder: XContentBuilder,
         params: ToXContent.Params,
-        secure: Boolean,
+        secure: Boolean
     ): XContentBuilder {
         builder.startObject()
         if (params.paramAsBoolean("with_type", false)) builder.startObject(type)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/action/Action.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/action/Action.kt
@@ -130,7 +130,9 @@ data class Action(
                     NAME_FIELD -> name = xcp.textOrNull()
                     DESTINATION_ID_FIELD -> destinationId = xcp.textOrNull()
                     SUBJECT_TEMPLATE_FIELD -> {
-                        subjectTemplate = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) null else {
+                        subjectTemplate = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                            null
+                        } else {
                             Script.parse(xcp, Script.DEFAULT_TEMPLATE_LANG)
                         }
                     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/AlertTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/AlertTests.kt
@@ -50,7 +50,7 @@ class AlertTests {
         assertEquals(
             templateArgs[Alert.PARENTS_BUCKET_PATH],
             alert.aggregationResultBucket?.parentBucketPath,
-            "Template args parentBucketPath does not match",
+            "Template args parentBucketPath does not match"
         )
     }
 
@@ -66,8 +66,11 @@ class AlertTests {
     @Test
     fun `test alert in audit state`() {
         val auditAlert = Alert(
-            randomQueryLevelMonitor(), randomQueryLevelTrigger(), Instant.now().truncatedTo(ChronoUnit.MILLIS),
-            null, actionExecutionResults = listOf(randomActionExecutionResult())
+            randomQueryLevelMonitor(),
+            randomQueryLevelTrigger(),
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            null,
+            actionExecutionResults = listOf(randomActionExecutionResult())
         )
         Assertions.assertFalse(auditAlert.isAcknowledged(), "Alert should not be in acknowledged state")
     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -208,7 +208,7 @@ fun randomWorkflowWithDelegates(
     enabled: Boolean = Random().nextBoolean(),
     enabledTime: Instant? = if (enabled) Instant.now().truncatedTo(ChronoUnit.MILLIS) else null,
     lastUpdateTime: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
-    triggers: List<Trigger> = (1..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { randomChainedAlertTrigger() },
+    triggers: List<Trigger> = (1..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { randomChainedAlertTrigger() }
 ): Workflow {
     return Workflow(
         name = name, workflowType = Workflow.WorkflowType.COMPOSITE, enabled = enabled, inputs = input,
@@ -286,9 +286,11 @@ fun randomDocumentLevelTrigger(
         name = name,
         severity = severity,
         condition = condition,
-        actions = if (actions.isEmpty() && destinationId.isNotBlank())
+        actions = if (actions.isEmpty() && destinationId.isNotBlank()) {
             (0..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { randomAction(destinationId = destinationId) }
-        else actions
+        } else {
+            actions
+        }
     )
 }
 
@@ -307,7 +309,9 @@ fun randomChainedAlertTrigger(
         condition = condition,
         actions = if (actions.isEmpty() && destinationId.isNotBlank()) {
             (0..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { randomAction(destinationId = destinationId) }
-        } else actions
+        } else {
+            actions
+        }
     )
 }
 
@@ -530,14 +534,18 @@ fun randomAlert(monitor: Monitor = randomQueryLevelMonitor()): Alert {
     val clusterCount = (-1..5).random()
     val clusters = if (clusterCount == -1) null else (0..clusterCount).map { "index-$it" }
     return Alert(
-        monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,
-        actionExecutionResults = actionExecutionResults, clusters = clusters
+        monitor,
+        trigger,
+        Instant.now().truncatedTo(ChronoUnit.MILLIS),
+        null,
+        actionExecutionResults = actionExecutionResults,
+        clusters = clusters
     )
 }
 
 fun randomChainedAlert(
     workflow: Workflow = randomWorkflow(),
-    trigger: ChainedAlertTrigger = randomChainedAlertTrigger(),
+    trigger: ChainedAlertTrigger = randomChainedAlertTrigger()
 ): Alert {
     return Alert(
         startTime = Instant.now(),
@@ -561,7 +569,10 @@ fun randomAlertWithAggregationResultBucket(monitor: Monitor = randomBucketLevelM
     val trigger = randomBucketLevelTrigger()
     val actionExecutionResults = mutableListOf(randomActionExecutionResult(), randomActionExecutionResult())
     return Alert(
-        monitor, trigger, Instant.now().truncatedTo(ChronoUnit.MILLIS), null,
+        monitor,
+        trigger,
+        Instant.now().truncatedTo(ChronoUnit.MILLIS),
+        null,
         actionExecutionResults = actionExecutionResults,
         aggregationResultBucket = AggregationResultBucket(
             "parent_bucket_path_1",

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/AcknowledgeAlertResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/AcknowledgeAlertResponseTests.kt
@@ -15,7 +15,6 @@ class AcknowledgeAlertResponseTests {
 
     @Test
     fun `test acknowledge alert response`() {
-
         val acknowledged = mutableListOf(
             Alert(
                 id = "1234",

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequestTests.kt
@@ -11,7 +11,6 @@ class DeleteMonitorRequestTests {
 
     @Test
     fun `test delete monitor request`() {
-
         val req = DeleteMonitorRequest("1234", WriteRequest.RefreshPolicy.IMMEDIATE)
         assertNotNull(req)
         assertEquals("1234", req.monitorId)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequestTests.kt
@@ -9,7 +9,6 @@ class DeleteWorkflowRequestTests {
 
     @Test
     fun `test delete workflow request`() {
-
         val req = DeleteWorkflowRequest("1234", true)
         Assert.assertNotNull(req)
         Assert.assertEquals("1234", req.workflowId)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequestTests.kt
@@ -13,7 +13,6 @@ internal class GetAlertsRequestTests {
 
     @Test
     fun `test get alerts request`() {
-
         val table = Table("asc", "sortString", null, 1, 0, "")
 
         val req = GetAlertsRequest(
@@ -24,7 +23,7 @@ internal class GetAlertsRequestTests {
             alertIndex = null,
             monitorIds = listOf("1", "2"),
             alertIds = listOf("alert1", "alert2"),
-            workflowIds = listOf("w1", "w2"),
+            workflowIds = listOf("w1", "w2")
         )
         assertNotNull(req)
 
@@ -47,7 +46,6 @@ internal class GetAlertsRequestTests {
 
     @Test
     fun `test get alerts request with filter`() {
-
         val table = Table("asc", "sortString", null, 1, 0, "")
         val req = GetAlertsRequest(table, "1", "active", null, null)
         assertNotNull(req)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsRequestTests.kt
@@ -13,7 +13,6 @@ internal class GetFindingsRequestTests {
 
     @Test
     fun `test get findings request`() {
-
         val table = Table("asc", "sortString", null, 1, 0, "")
 
         val req = GetFindingsRequest("2121", table, "1", "finding_index_name", listOf("1", "2"))

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetFindingsResponseTests.kt
@@ -15,7 +15,6 @@ internal class GetFindingsResponseTests {
 
     @Test
     fun `test get findings response`() {
-
         // Alerting GetFindingsResponse mock #1
         val finding1 = Finding(
             "1",

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequestTests.kt
@@ -14,7 +14,6 @@ import org.opensearch.test.OpenSearchTestCase
 class GetMonitorRequestTests : OpenSearchTestCase() {
 
     fun `test get monitor request`() {
-
         val req = GetMonitorRequest("1234", 1L, RestRequest.Method.GET, FetchSourceContext.FETCH_SOURCE)
         assertNotNull(req)
 
@@ -29,7 +28,6 @@ class GetMonitorRequestTests : OpenSearchTestCase() {
     }
 
     fun `test get monitor request without src context`() {
-
         val req = GetMonitorRequest("1234", 1L, RestRequest.Method.GET, null)
         assertNotNull(req)
 
@@ -44,7 +42,6 @@ class GetMonitorRequestTests : OpenSearchTestCase() {
     }
 
     fun `test head monitor request`() {
-
         val req = GetMonitorRequest("1234", 2L, RestRequest.Method.HEAD, FetchSourceContext.FETCH_SOURCE)
         assertNotNull(req)
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequestTests.kt
@@ -13,7 +13,6 @@ internal class GetWorkflowAlertsRequestTests {
 
     @Test
     fun `test get alerts request`() {
-
         val table = Table("asc", "sortString", null, 1, 0, "")
 
         val req = GetWorkflowAlertsRequest(
@@ -48,7 +47,6 @@ internal class GetWorkflowAlertsRequestTests {
 
     @Test
     fun `test get alerts request with custom alerts and associated alerts indices`() {
-
         val table = Table("asc", "sortString", null, 1, 0, "")
 
         val req = GetWorkflowAlertsRequest(

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/GetWorkflowResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/GetWorkflowResponseTests.kt
@@ -20,7 +20,12 @@ class GetWorkflowResponseTests {
     fun testGetWorkflowResponse() {
         val workflow = randomWorkflow(auditDelegateMonitorAlerts = false)
         val response = GetWorkflowResponse(
-            id = "id", version = 1, seqNo = 1, primaryTerm = 1, status = RestStatus.OK, workflow = workflow
+            id = "id",
+            version = 1,
+            seqNo = 1,
+            primaryTerm = 1,
+            status = RestStatus.OK,
+            workflow = workflow
         )
         val out = BytesStreamOutput()
         response.writeTo(out)
@@ -50,7 +55,12 @@ class GetWorkflowResponseTests {
             triggers = listOf()
         )
         val response = GetWorkflowResponse(
-            id = "id", version = 1, seqNo = 1, primaryTerm = 1, status = RestStatus.OK, workflow = workflow
+            id = "id",
+            version = 1,
+            seqNo = 1,
+            primaryTerm = 1,
+            status = RestStatus.OK,
+            workflow = workflow
         )
         val out = BytesStreamOutput()
         response.writeTo(out)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequestTests.kt
@@ -20,9 +20,12 @@ class IndexMonitorRequestTests {
 
     @Test
     fun `test index monitor post request`() {
-
         val req = IndexMonitorRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         )
         Assertions.assertNotNull(req)
@@ -41,7 +44,11 @@ class IndexMonitorRequestTests {
     @Test
     fun `test index bucket monitor post request`() {
         val req = IndexMonitorRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomBucketLevelMonitor()
         )
         Assertions.assertNotNull(req)
@@ -61,7 +68,11 @@ class IndexMonitorRequestTests {
     @Test
     fun `Index bucket monitor serialize and deserialize transport object should be equal`() {
         val bucketLevelMonitorRequest = IndexMonitorRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomBucketLevelMonitor()
         )
 
@@ -80,9 +91,12 @@ class IndexMonitorRequestTests {
 
     @Test
     fun `test index monitor put request`() {
-
         val req = IndexMonitorRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomQueryLevelMonitor().copy(inputs = listOf(SearchInput(emptyList(), SearchSourceBuilder())))
         )
         Assertions.assertNotNull(req)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequestTests.kt
@@ -29,9 +29,12 @@ class IndexWorkflowRequestTests {
 
     @Test
     fun `test index workflow post request`() {
-
         val req = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomWorkflow(auditDelegateMonitorAlerts = false)
         )
         Assertions.assertNotNull(req)
@@ -51,7 +54,11 @@ class IndexWorkflowRequestTests {
     @Test
     fun `test index composite workflow post request`() {
         val req = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomWorkflow()
         )
         Assertions.assertNotNull(req)
@@ -71,7 +78,11 @@ class IndexWorkflowRequestTests {
     @Test
     fun `Index composite workflow serialize and deserialize transport object should be equal`() {
         val compositeWorkflowRequest = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.POST,
             randomWorkflow()
         )
 
@@ -89,9 +100,12 @@ class IndexWorkflowRequestTests {
 
     @Test
     fun `test index workflow put request`() {
-
         val req = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflow()
         )
         Assertions.assertNotNull(req)
@@ -110,7 +124,11 @@ class IndexWorkflowRequestTests {
     @Test
     fun `test validate`() {
         val req = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflow(monitorIds = emptyList())
         )
         Assertions.assertNotNull(req)
@@ -120,7 +138,11 @@ class IndexWorkflowRequestTests {
         Assert.assertTrue(validate!!.message!!.contains("Delegates list can not be empty.;"))
         // Duplicate delegate
         val req1 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflow(monitorIds = listOf("1L", "1L", "2L"))
         )
         validate = req1.validate()
@@ -133,7 +155,11 @@ class IndexWorkflowRequestTests {
             Delegate(2, "monitor-3")
         )
         val req2 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = listOf(CompositeInput(Sequence(delegates = delegates)))
             )
@@ -148,7 +174,11 @@ class IndexWorkflowRequestTests {
             Delegate(3, "monitor-3", ChainedMonitorFindings("monitor-x"))
         )
         val req3 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = listOf(CompositeInput(Sequence(delegates = delegates)))
             )
@@ -163,7 +193,11 @@ class IndexWorkflowRequestTests {
             Delegate(2, "monitor-3", ChainedMonitorFindings("monitor-2"))
         )
         val req4 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = listOf(CompositeInput(Sequence(delegates = delegates)))
             )
@@ -177,7 +211,11 @@ class IndexWorkflowRequestTests {
             monitorsIds.add(UUID.randomUUID().toString())
         }
         val req5 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflow(
                 monitorIds = monitorsIds
             )
@@ -187,7 +225,11 @@ class IndexWorkflowRequestTests {
         Assert.assertTrue(validate!!.message!!.contains("Delegates list can not be larger then 25."))
         // Input list empty
         val req6 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = emptyList()
             )
@@ -204,11 +246,15 @@ class IndexWorkflowRequestTests {
         delegates = listOf(
             Delegate(1, "monitor-1"),
             Delegate(2, "monitor-2"),
-            Delegate(3, "monitor-3", ChainedMonitorFindings(null, listOf("monitor-1", "monitor-2"))),
+            Delegate(3, "monitor-3", ChainedMonitorFindings(null, listOf("monitor-1", "monitor-2")))
 
         )
         val req7 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = listOf(CompositeInput(Sequence(delegates = delegates)))
             )
@@ -216,7 +262,11 @@ class IndexWorkflowRequestTests {
         assertNull(req7.validate())
         try {
             IndexWorkflowRequest(
-                "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+                "1234",
+                1L,
+                2L,
+                WriteRequest.RefreshPolicy.IMMEDIATE,
+                RestRequest.Method.PUT,
                 randomWorkflowWithDelegates(
                     input = listOf(CompositeInput(Sequence(delegates = delegates)), CompositeInput(Sequence(delegates = delegates)))
                 )
@@ -230,11 +280,15 @@ class IndexWorkflowRequestTests {
         delegates = listOf(
             Delegate(1, "monitor-1"),
             Delegate(3, "monitor-2"),
-            Delegate(2, "monitor-3", ChainedMonitorFindings(null, listOf("monitor-1", "monitor-2"))),
+            Delegate(2, "monitor-3", ChainedMonitorFindings(null, listOf("monitor-1", "monitor-2")))
 
         )
         val req8 = IndexWorkflowRequest(
-            "1234", 1L, 2L, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.PUT,
+            "1234",
+            1L,
+            2L,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            RestRequest.Method.PUT,
             randomWorkflowWithDelegates(
                 input = listOf(CompositeInput(Sequence(delegates = delegates)))
             )

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/PublishFindingsRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/PublishFindingsRequestTests.kt
@@ -11,7 +11,6 @@ class PublishFindingsRequestTests {
 
     @Test
     fun `test delete monitor request`() {
-
         val finding = randomFinding()
         val monitorId = "mid"
         val req = PublishFindingsRequest(monitorId, finding)

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/FindingTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/FindingTests.kt
@@ -24,7 +24,7 @@ internal class FindingTests {
         assertEquals(
             templateArgs[Finding.MONITOR_NAME_FIELD],
             finding.monitorName,
-            "Template args 'monitorName' field does not match:",
+            "Template args 'monitorName' field does not match:"
         )
         assertEquals(
             templateArgs[Finding.QUERIES_FIELD],

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -277,13 +277,15 @@ class XContentTests {
         val cmf1 = ChainedMonitorFindings(monitorId = "m1")
         val cmf1String = cmf1.toJsonString()
         Assertions.assertEquals(
-            ChainedMonitorFindings.parse(parser(cmf1String)), cmf1,
+            ChainedMonitorFindings.parse(parser(cmf1String)),
+            cmf1,
             "Round tripping chained monitor findings failed"
         )
         val cmf2 = ChainedMonitorFindings(monitorIds = listOf("m1", "m2"))
         val cmf2String = cmf2.toJsonString()
         Assertions.assertEquals(
-            ChainedMonitorFindings.parse(parser(cmf2String)), cmf2,
+            ChainedMonitorFindings.parse(parser(cmf2String)),
+            cmf2,
             "Round tripping chained monitor findings failed"
         )
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -202,7 +202,11 @@ internal class NotificationsPluginInterfaceTests {
         }.whenever(client).execute(any(ActionType::class.java), any(), any())
 
         NotificationsPluginInterface.sendNotification(
-            client, notificationInfo, channelMessage, listOf("channelId1", "channelId2"), listener
+            client,
+            notificationInfo,
+            channelMessage,
+            listOf("channelId1", "channelId2"),
+            listener
         )
         verify(listener, times(1)).onResponse(eq(response))
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/CreateNotificationConfigRequestTests.kt
@@ -125,6 +125,7 @@ internal class CreateNotificationConfigRequestTests {
         assertNull(recreatedObject.validate())
         assertEquals(configRequest.notificationConfig, recreatedObject.notificationConfig)
     }
+
     @Test
     fun `Create config serialize and deserialize transport object should be equal microsoft teams`() {
         val configRequest = CreateNotificationConfigRequest(
@@ -214,6 +215,7 @@ internal class CreateNotificationConfigRequestTests {
         assertNull(recreatedObject.validate())
         assertEquals(configRequest.notificationConfig, recreatedObject.notificationConfig)
     }
+
     @Test
     fun `Create config serialize and deserialize using json object should be equal microsoft teams`() {
         val configRequest = CreateNotificationConfigRequest(
@@ -309,6 +311,7 @@ internal class CreateNotificationConfigRequestTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { CreateNotificationConfigRequest.parse(it) }
         assertEquals(config, recreatedObject.notificationConfig)
     }
+
     @Test
     fun `Create config should deserialize json object using parser microsoft teams`() {
         val sampleMicrosoftTeams = MicrosoftTeams("https://domain.com/sample_microsoft_teams_url#1234567890")

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/SendNotificationResponseTests.kt
@@ -22,7 +22,6 @@ internal class SendNotificationResponseTests {
 
     @Test
     fun `Create response serialize and deserialize transport object should be equal`() {
-
         val sampleEvent = getSampleEvent()
 
         val recreatedObject = recreateObject(sampleEvent) { SendNotificationResponse(it) }
@@ -31,7 +30,6 @@ internal class SendNotificationResponseTests {
 
     @Test
     fun `Create response serialize and deserialize using json object should be equal`() {
-
         val sampleEvent = getSampleEvent()
 
         val jsonString = getJsonString(sampleEvent)

--- a/src/test/kotlin/org/opensearch/commons/notifications/action/UpdateNotificationConfigRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/action/UpdateNotificationConfigRequestTests.kt
@@ -119,6 +119,7 @@ internal class UpdateNotificationConfigRequestTests {
         assertEquals(configRequest.notificationConfig, recreatedObject.notificationConfig)
         assertEquals("config_id", recreatedObject.configId)
     }
+
     @Test
     fun `Update config serialize and deserialize transport object should be equal Microsoft Teams`() {
         val configRequest = UpdateNotificationConfigRequest("config_id", createMicrosoftTeamsContentConfigObject())
@@ -187,6 +188,7 @@ internal class UpdateNotificationConfigRequestTests {
         assertEquals(configRequest.notificationConfig, recreatedObject.notificationConfig)
         assertEquals("config_id", recreatedObject.configId)
     }
+
     @Test
     fun `Update config serialize and deserialize using json object should be equal microsoft Teams`() {
         val configRequest = UpdateNotificationConfigRequest("config_id", createMicrosoftTeamsContentConfigObject())

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/NotificationConfigTests.kt
@@ -202,7 +202,6 @@ internal class NotificationConfigTests {
     }
 
     @Test
-
     fun `Config should safely ignore unknown config type in json object`() {
         val sampleSlack = Slack("https://domain.com/sample_slack_url#1234567890")
         val sampleConfig = NotificationConfig(

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/SmtpAccountTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/SmtpAccountTests.kt
@@ -71,7 +71,8 @@ internal class SmtpAccountTests {
     fun `SmtpAccount should safely ignore extra field in json object`() {
         val sampleSmtpAccount = SmtpAccount(
             "domain.com",
-            1234, MethodType.START_TLS,
+            1234,
+            MethodType.START_TLS,
             "from@domain.com"
         )
         val jsonString = """

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/config/ConfigPropertiesTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/config/ConfigPropertiesTests.kt
@@ -76,6 +76,7 @@ internal class ConfigPropertiesTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { createConfigData(ConfigType.WEBHOOK, it) }
         assertEquals(sampleWebhook, recreatedObject)
     }
+
     @Test
     fun `Validate config data parse Microsoft Teams`() {
         val sampleMicrosoftTeams = MicrosoftTeams("https://domain.com/sample_url#1234567890")
@@ -83,6 +84,7 @@ internal class ConfigPropertiesTests {
         val recreatedObject = createObjectFromJsonString(jsonString) { createConfigData(ConfigType.MICROSOFT_TEAMS, it) }
         assertEquals(sampleMicrosoftTeams, recreatedObject)
     }
+
     @Test
     fun `Validate config data parse EmailGroup`() {
         val sampleEmailGroup = EmailGroup(listOf(EmailRecipient("email1@email.com"), EmailRecipient("email2@email.com")))


### PR DESCRIPTION
### Description
Manual Backport of #585 to 2.x

Cherry picked `418f56f97745f999d951a201caee3808802cb3a8` and `816235c090c27716255312dd2d216f6b007f6e18` then ran `./gradlew ktlintformat` to fix ktlint.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
