### PR TITLE
Forced ktlint to use logback-core:1.2.13, and logback-classic:1.2.13 to address CVE.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,12 @@ dependencies {
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 
-    ktlint "com.pinterest:ktlint:0.45.1"
+    add("ktlint", "com.pinterest:ktlint:0.45.1") {
+        exclude group: "ch.qos.logback", module: "logback-classic"
+        exclude group: "ch.qos.logback", module: "logback-core"
+    }
+    add("ktlint", "ch.qos.logback:logback-core:1.2.13")
+    add("ktlint", "ch.qos.logback:logback-classic:1.2.13")
 }
 
 test {


### PR DESCRIPTION
### Description
Forced ktlint to use logback-core:1.2.13, and logback-classic:1.2.13 to address CVE.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
