### PR TITLE
[Backport 2.9] add queryFieldNames field in Doc Level Queries (#582) (#597)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -8,14 +8,14 @@ import org.opensearch.core.xcontent.ToXContent
 import org.opensearch.core.xcontent.XContentBuilder
 import org.opensearch.core.xcontent.XContentParser
 import java.io.IOException
-import java.lang.IllegalArgumentException
 import java.util.UUID
 
 data class DocLevelQuery(
     val id: String = UUID.randomUUID().toString(),
     val name: String,
     val query: String,
-    val tags: List<String> = mutableListOf()
+    val tags: List<String> = mutableListOf(),
+    val queryFieldNames: List<String> = mutableListOf(),
 ) : BaseModel {
 
     init {
@@ -31,7 +31,8 @@ data class DocLevelQuery(
         sin.readString(), // id
         sin.readString(), // name
         sin.readString(), // query
-        sin.readStringList() // tags
+        sin.readStringList(), // tags,
+        sin.readStringList() // fieldsBeingQueried
     )
 
     fun asTemplateArg(): Map<String, Any> {
@@ -39,7 +40,8 @@ data class DocLevelQuery(
             QUERY_ID_FIELD to id,
             NAME_FIELD to name,
             QUERY_FIELD to query,
-            TAGS_FIELD to tags
+            TAGS_FIELD to tags,
+            QUERY_FIELD_NAMES_FIELD to queryFieldNames
         )
     }
 
@@ -49,6 +51,7 @@ data class DocLevelQuery(
         out.writeString(name)
         out.writeString(query)
         out.writeStringCollection(tags)
+        out.writeStringCollection(queryFieldNames)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -57,6 +60,7 @@ data class DocLevelQuery(
             .field(NAME_FIELD, name)
             .field(QUERY_FIELD, query)
             .field(TAGS_FIELD, tags.toTypedArray())
+            .field(QUERY_FIELD_NAMES_FIELD, queryFieldNames.toTypedArray())
             .endObject()
         return builder
     }
@@ -66,6 +70,7 @@ data class DocLevelQuery(
         const val NAME_FIELD = "name"
         const val QUERY_FIELD = "query"
         const val TAGS_FIELD = "tags"
+        const val QUERY_FIELD_NAMES_FIELD = "query_field_names"
         const val NO_ID = ""
         val INVALID_CHARACTERS: List<String> = listOf(" ", "[", "]", "{", "}", "(", ")")
 
@@ -76,6 +81,7 @@ data class DocLevelQuery(
             lateinit var query: String
             lateinit var name: String
             val tags: MutableList<String> = mutableListOf()
+            val queryFieldNames: MutableList<String> = mutableListOf()
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -88,6 +94,7 @@ data class DocLevelQuery(
                         name = xcp.text()
                         validateQuery(name)
                     }
+
                     QUERY_FIELD -> query = xcp.text()
                     TAGS_FIELD -> {
                         XContentParserUtils.ensureExpectedToken(
@@ -101,6 +108,18 @@ data class DocLevelQuery(
                             tags.add(tag)
                         }
                     }
+
+                    QUERY_FIELD_NAMES_FIELD -> {
+                        XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY,
+                            xcp.currentToken(),
+                            xcp
+                        )
+                        while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
+                            val field = xcp.text()
+                            queryFieldNames.add(field)
+                        }
+                    }
                 }
             }
 
@@ -108,7 +127,8 @@ data class DocLevelQuery(
                 id = id,
                 name = name,
                 query = query,
-                tags = tags
+                tags = tags,
+                queryFieldNames = queryFieldNames
             )
         }
 
@@ -129,4 +149,18 @@ data class DocLevelQuery(
             }
         }
     }
+
+    // constructor for java plugins' convenience to optionally avoid passing empty list for 'fieldsBeingQueried' field
+    constructor(
+        id: String,
+        name: String,
+        query: String,
+        tags: MutableList<String>,
+    ) : this(
+        id = id,
+        name = name,
+        query = query,
+        tags = tags,
+        queryFieldNames = emptyList()
+    )
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -11,6 +11,7 @@ import org.opensearch.commons.alerting.randomAction
 import org.opensearch.commons.alerting.randomActionExecutionPolicy
 import org.opensearch.commons.alerting.randomBucketLevelTrigger
 import org.opensearch.commons.alerting.randomChainedAlertTrigger
+import org.opensearch.commons.alerting.randomDocLevelQuery
 import org.opensearch.commons.alerting.randomDocumentLevelTrigger
 import org.opensearch.commons.alerting.randomQueryLevelMonitor
 import org.opensearch.commons.alerting.randomQueryLevelTrigger
@@ -19,6 +20,7 @@ import org.opensearch.commons.alerting.randomUser
 import org.opensearch.commons.alerting.randomUserEmpty
 import org.opensearch.commons.authuser.User
 import org.opensearch.search.builder.SearchSourceBuilder
+import kotlin.test.assertTrue
 
 class WriteableTests {
 
@@ -110,6 +112,29 @@ class WriteableTests {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newTrigger = DocumentLevelTrigger.readFrom(sin)
         Assertions.assertEquals(trigger, newTrigger, "Round tripping DocumentLevelTrigger doesn't work")
+    }
+
+    @Test
+    fun `test doc-level query as stream`() {
+        val dlq = randomDocLevelQuery()
+        val out = BytesStreamOutput()
+        dlq.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newDlq = DocLevelQuery.readFrom(sin)
+        Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
+        assertTrue(newDlq.queryFieldNames.isEmpty())
+    }
+
+    @Test
+    fun `test doc-level query with query Field Names as stream`() {
+        val dlq = randomDocLevelQuery().copy(queryFieldNames = listOf("f1", "f2"))
+        val out = BytesStreamOutput()
+        dlq.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newDlq = DocLevelQuery.readFrom(sin)
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[0]))
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[1]))
+        Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
     }
 
     @Test

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -394,6 +394,30 @@ class XContentTests {
     }
 
     @Test
+    fun `test doc level query toXcontent`() {
+        val dlq = DocLevelQuery("id", "name", "query", listOf("t1", "t2"))
+        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
+        Assertions.assertEquals(
+            dlq,
+            parsedDlq,
+            "Round tripping Doc level query doesn't work"
+        )
+    }
+
+    @Test
+    fun `test doc level query toXcontent with query field names`() {
+        val dlq = DocLevelQuery("id", "name", "query", listOf("t1", "t2"), listOf("f1", "f2"))
+        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
+        Assertions.assertEquals(
+            dlq,
+            parsedDlq,
+            "Round tripping Doc level query doesn't work"
+        )
+    }
+
+    @Test
     fun `test alert parsing`() {
         val alert = randomAlert()
 


### PR DESCRIPTION
* add queryFieldNames field in Doc Level Queries

* add tests to verify queryFieldNames field in DocLevelQuery

---------

(cherry picked from commit 75925dcdbc98e29c07e007676ea6c68ee7468dec)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
