### PR TITLE
[Backport 2.7] add queryFieldNames field in Doc Level Queries (#582)

### DIFF
--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -10,6 +10,7 @@ import org.opensearch.commons.alerting.model.action.Throttle
 import org.opensearch.commons.alerting.randomAction
 import org.opensearch.commons.alerting.randomActionExecutionPolicy
 import org.opensearch.commons.alerting.randomBucketLevelTrigger
+import org.opensearch.commons.alerting.randomDocLevelQuery
 import org.opensearch.commons.alerting.randomDocumentLevelTrigger
 import org.opensearch.commons.alerting.randomQueryLevelMonitor
 import org.opensearch.commons.alerting.randomQueryLevelTrigger
@@ -18,6 +19,7 @@ import org.opensearch.commons.alerting.randomUser
 import org.opensearch.commons.alerting.randomUserEmpty
 import org.opensearch.commons.authuser.User
 import org.opensearch.search.builder.SearchSourceBuilder
+import kotlin.test.assertTrue
 
 class WriteableTests {
 
@@ -119,6 +121,18 @@ class WriteableTests {
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newInput = SearchInput(sin)
         Assertions.assertEquals(input, newInput, "Round tripping MonitorRunResult doesn't work")
+    }
+
+    @Test
+    fun `test doc-level query with query Field Names as stream`() {
+        val dlq = randomDocLevelQuery().copy(queryFieldNames = listOf("f1", "f2"))
+        val out = BytesStreamOutput()
+        dlq.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newDlq = DocLevelQuery.readFrom(sin)
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[0]))
+        assertTrue(newDlq.queryFieldNames.contains(dlq.queryFieldNames[1]))
+        Assertions.assertEquals(dlq, newDlq, "Round tripping DocLevelQuery doesn't work")
     }
 
     @Test

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -359,6 +359,18 @@ class XContentTests {
     }
 
     @Test
+    fun `test doc level query toXcontent with query field names`() {
+        val dlq = DocLevelQuery("id", "name", "query", listOf("t1", "t2"), listOf("f1", "f2"))
+        val dlqString = dlq.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDlq = DocLevelQuery.parse(parser(dlqString))
+        Assertions.assertEquals(
+            dlq,
+            parsedDlq,
+            "Round tripping Doc level query doesn't work"
+        )
+    }
+
+    @Test
     fun `test alert parsing`() {
         val alert = randomAlert()
 


### PR DESCRIPTION
### Description
Manual backport to 2.7 
- #582 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
