### PR TITLE
Change doc level query name validation

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -80,7 +80,7 @@ data class DocLevelQuery(
         const val QUERY_FIELD_NAMES_FIELD = "query_field_names"
         const val NO_ID = ""
         val INVALID_CHARACTERS: List<String> = listOf(" ", "[", "]", "{", "}", "(", ")")
-        val QUERY_NAME_REGEX = "^.{1,256}$".toRegex() // regex to restrict string length to 1-256 chars
+        val QUERY_NAME_REGEX = "^.{0,256}$".toRegex() // regex to restrict string length 256 chars
 
         @JvmStatic
         @Throws(IOException::class)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -171,7 +171,7 @@ data class DocLevelQuery(
         }
         private fun validateQueryName(stringVal: String) {
             if (!stringVal.matches(QUERY_NAME_REGEX)) {
-                throw IllegalArgumentException("The query name, $stringVal, can be max 256 characters.")
+                throw IllegalArgumentException("The query name, $stringVal, should be between 1 - 256 characters.")
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -80,7 +80,7 @@ data class DocLevelQuery(
         const val QUERY_FIELD_NAMES_FIELD = "query_field_names"
         const val NO_ID = ""
         val INVALID_CHARACTERS: List<String> = listOf(" ", "[", "]", "{", "}", "(", ")")
-        val QUERY_NAME_REGEX = "^.{0,256}$".toRegex() // regex to restrict string length 256 chars
+        val QUERY_NAME_REGEX = "^.{1,256}$".toRegex() // regex to restrict string length between 1 - 256 chars
 
         @JvmStatic
         @Throws(IOException::class)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -22,9 +22,9 @@ data class DocLevelQuery(
 
     init {
         // Ensure the name and tags have valid characters
-        validateQuery(name)
+        validateQueryName(name)
         for (tag in tags) {
-            validateQuery(tag)
+            validateQueryTag(tag)
         }
     }
 
@@ -80,6 +80,7 @@ data class DocLevelQuery(
         const val QUERY_FIELD_NAMES_FIELD = "query_field_names"
         const val NO_ID = ""
         val INVALID_CHARACTERS: List<String> = listOf(" ", "[", "]", "{", "}", "(", ")")
+        val QUERY_NAME_REGEX = "^.{1,256}$".toRegex() // regex to restrict string length to 1-256 chars
 
         @JvmStatic
         @Throws(IOException::class)
@@ -100,7 +101,7 @@ data class DocLevelQuery(
                     QUERY_ID_FIELD -> id = xcp.text()
                     NAME_FIELD -> {
                         name = xcp.text()
-                        validateQuery(name)
+                        validateQueryName(name)
                     }
 
                     QUERY_FIELD -> query = xcp.text()
@@ -112,7 +113,7 @@ data class DocLevelQuery(
                         )
                         while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                             val tag = xcp.text()
-                            validateQuery(tag)
+                            validateQueryTag(tag)
                             tags.add(tag)
                         }
                     }
@@ -160,13 +161,18 @@ data class DocLevelQuery(
         }
 
         // TODO: add test for this
-        private fun validateQuery(stringVal: String) {
+        private fun validateQueryTag(stringVal: String) {
             for (inValidChar in INVALID_CHARACTERS) {
                 if (stringVal.contains(inValidChar)) {
                     throw IllegalArgumentException(
-                        "They query name or tag, $stringVal, contains an invalid character: [' ','[',']','{','}','(',')']"
+                        "The query tag, $stringVal, contains an invalid character: [' ','[',']','{','}','(',')']"
                     )
                 }
+            }
+        }
+        private fun validateQueryName(stringVal: String) {
+            if (!stringVal.matches(QUERY_NAME_REGEX)) {
+                throw IllegalArgumentException("The query name, $stringVal, can be max 256 characters.")
             }
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelQuery.kt
@@ -160,7 +160,6 @@ data class DocLevelQuery(
             return DocLevelQuery(sin)
         }
 
-        // TODO: add test for this
         private fun validateQueryTag(stringVal: String) {
             for (inValidChar in INVALID_CHARACTERS) {
                 if (stringVal.contains(inValidChar)) {

--- a/src/main/kotlin/org/opensearch/commons/utils/ValidationHelpers.kt
+++ b/src/main/kotlin/org/opensearch/commons/utils/ValidationHelpers.kt
@@ -11,6 +11,9 @@ import java.util.regex.Pattern
 // Valid ID characters = (All Base64 chars + "_-") to support UUID format and Base64 encoded IDs
 private val VALID_ID_CHARS: Set<Char> = (('a'..'z') + ('A'..'Z') + ('0'..'9') + '+' + '/' + '_' + '-').toSet()
 
+// Invalid characters in a new name field: [* ? < > | #]
+private val INVALID_NAME_CHARS = "^\\*\\?<>|#"
+
 fun validateUrl(urlString: String) {
     require(isValidUrl(urlString)) { "Invalid URL or unsupported" }
 }
@@ -52,4 +55,16 @@ fun isValidId(idString: String): Boolean {
 fun validateIamRoleArn(roleArn: String) {
     val roleArnRegex = Pattern.compile("^arn:aws(-[^:]+)?:iam::([0-9]{12}):([a-zA-Z_0-9+=,.@\\-_/]+)$")
     require(roleArnRegex.matcher(roleArn).find()) { "Invalid AWS role ARN: $roleArn " }
+}
+
+fun isValidName(name: String): Boolean {
+    // Regex to restrict string so that it cannot start with [_, -, +],
+    // contain two consecutive periods or contain invalid chars
+    val regex = Regex("""^(?![_\-\+])(?!.*\.\.)[^$INVALID_NAME_CHARS]+$""")
+
+    return name.matches(regex)
+}
+
+fun getInvalidNameChars(): String {
+    return INVALID_NAME_CHARS
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
@@ -44,10 +44,10 @@ class DocLevelMonitorInputTests {
     @Test
     fun `test create Doc Level Query with invalid name length`() {
         val stringBuilder = StringBuilder()
-        repeat(256) {
+        repeat(257) {
             stringBuilder.append("a")
         }
-        val badString = stringBuilder.toString() + "b".repeat(256)
+        val badString = stringBuilder.toString()
 
         try {
             randomDocLevelQuery(name = badString)

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
@@ -52,7 +52,7 @@ class DocLevelMonitorInputTests {
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             Assertions.assertEquals(
-                "The query name, $emptyString, can be max 256 characters.",
+                "The query name, $emptyString, should be between 1 - 256 characters.",
                 e.message
             )
         }
@@ -68,7 +68,7 @@ class DocLevelMonitorInputTests {
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             Assertions.assertEquals(
-                "The query name, $badString, can be max 256 characters.",
+                "The query name, $badString, should be between 1 - 256 characters.",
                 e.message
             )
         }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
@@ -42,14 +42,19 @@ class DocLevelMonitorInputTests {
     }
 
     @Test
-    fun `test create Doc Level Query with invalid characters for name`() {
-        val badString = "query with space"
+    fun `test create Doc Level Query with invalid name length`() {
+        val stringBuilder = StringBuilder()
+        repeat(256) {
+            stringBuilder.append("a")
+        }
+        val badString = stringBuilder.toString() + "b".repeat(256)
+
         try {
             randomDocLevelQuery(name = badString)
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             Assertions.assertEquals(
-                "They query name or tag, $badString, contains an invalid character: [' ','[',']','{','}','(',')']",
+                "The query name, $badString, can be max 256 characters.",
                 e.message
             )
         }
@@ -64,7 +69,7 @@ class DocLevelMonitorInputTests {
             Assertions.fail("Expecting an illegal argument exception")
         } catch (e: IllegalArgumentException) {
             Assertions.assertEquals(
-                "They query name or tag, $badString, contains an invalid character: [' ','[',']','{','}','(',')']",
+                "The query tag, $badString, contains an invalid character: [' ','[',']','{','}','(',')']",
                 e.message
             )
         }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInputTests.kt
@@ -44,6 +44,20 @@ class DocLevelMonitorInputTests {
     @Test
     fun `test create Doc Level Query with invalid name length`() {
         val stringBuilder = StringBuilder()
+
+        // test empty string
+        val emptyString = stringBuilder.toString()
+        try {
+            randomDocLevelQuery(name = emptyString)
+            Assertions.fail("Expecting an illegal argument exception")
+        } catch (e: IllegalArgumentException) {
+            Assertions.assertEquals(
+                "The query name, $emptyString, can be max 256 characters.",
+                e.message
+            )
+        }
+
+        // test string with 257 chars
         repeat(257) {
             stringBuilder.append("a")
         }


### PR DESCRIPTION
### Description
Changes the doc level query name validation to restrict the name from 0-256 characters, similar to the validation done on the front end

Name validation regex modified from https://github.com/opensearch-project/alerting/blob/d2a590e744c920820536efc5e1a88a4185eeed74/alerting/src/main/kotlin/org/opensearch/alerting/util/IndexUtils.kt#L29
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
