### PR TITLE
Adding replication (CCR) plugin interface and classes to common-utils

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/replication/ReplicationPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/replication/ReplicationPluginInterface.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.replication
+
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.node.NodeClient
+import org.opensearch.commons.replication.action.StopIndexReplicationRequest
+import org.opensearch.commons.replication.action.ReplicationActions.STOP_REPLICATION_ACTION_TYPE
+import org.opensearch.commons.utils.recreateObject
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.common.io.stream.Writeable
+
+
+/**
+ * All the transport action plugin interfaces for the cross-cluster-replication plugin.
+ */
+object ReplicationPluginInterface {
+
+    /**
+     * Stop replication.
+     * @param client Node client for making transport action
+     * @param request The request object
+     * @param listener The listener for getting response
+     */
+
+    fun stopReplication(
+        client: NodeClient,
+        request: StopIndexReplicationRequest,
+        listener: ActionListener<AcknowledgedResponse>
+    ) {
+        return client.execute(
+            STOP_REPLICATION_ACTION_TYPE,
+            request,
+            wrapActionListener(listener) { response ->
+                recreateObject(response) {
+                    AcknowledgedResponse(it)
+                }
+            }
+        )
+    }
+
+    /**
+     * Wrap action listener on concrete response class by a new created one on ActionResponse.
+     * This is required because the response may be loaded by different classloader across plugins.
+     * The onResponse(ActionResponse) avoids type cast exception and give a chance to recreate
+     * the response object.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun <Response : AcknowledgedResponse> wrapActionListener(
+        listener: ActionListener<Response>,
+        recreate: (Writeable) -> Response
+    ): ActionListener<Response> {
+        return object : ActionListener<ActionResponse> {
+            override fun onResponse(response: ActionResponse) {
+                val recreated = response as? Response ?: recreate(response)
+                listener.onResponse(recreated)
+            }
+
+            override fun onFailure(exception: java.lang.Exception) {
+                listener.onFailure(exception)
+            }
+        } as ActionListener<Response>
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/replication/action/ReplicationActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/replication/action/ReplicationActions.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.replication.action
+
+import org.opensearch.action.ActionType
+import org.opensearch.action.support.master.AcknowledgedResponse
+
+/**
+ * All the transport action information for the Replication plugin
+ */
+object ReplicationActions {
+
+    /**
+     * Stop replication. Internal only - Inter plugin communication.
+     */
+    const val STOP_REPLICATION_NAME = "indices:admin/plugins/replication/index/stop"
+    const val STOP_REPLICATION_BASE_ACTION_NAME = "indices:admin/plugins/replication/index/unfollow"
+
+    /**
+     * Stop replication transport action type. Internal only - Inter plugin communication.
+     */
+    val STOP_REPLICATION_ACTION_TYPE =
+        ActionType(STOP_REPLICATION_NAME, ::AcknowledgedResponse)
+
+}

--- a/src/main/kotlin/org/opensearch/commons/replication/action/StopIndexReplicationRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/replication/action/StopIndexReplicationRequest.kt
@@ -1,0 +1,62 @@
+package org.opensearch.commons.replication.action
+
+import org.opensearch.action.ActionRequestValidationException
+import org.apache.logging.log4j.LogManager
+import org.opensearch.action.IndicesRequest
+import org.opensearch.action.support.IndicesOptions
+import org.opensearch.action.support.master.AcknowledgedRequest
+import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.common.io.stream.StreamOutput
+import org.opensearch.core.xcontent.*
+class StopIndexReplicationRequest : AcknowledgedRequest<StopIndexReplicationRequest>, IndicesRequest.Replaceable, ToXContentObject  {
+    lateinit var indexName: String
+    constructor(indexName: String) {
+        this.indexName = indexName
+    }
+
+    private constructor() {
+    }
+
+    constructor(inp: StreamInput): super(inp) {
+        indexName = inp.readString()
+    }
+    companion object {
+        private val PARSER = ObjectParser<StopIndexReplicationRequest, Void>("StopReplicationRequestParser") {
+            StopIndexReplicationRequest()
+        }
+
+        fun fromXContent(parser: XContentParser, followerIndex: String): StopIndexReplicationRequest {
+            val stopIndexReplicationRequest = PARSER.parse(parser, null)
+            stopIndexReplicationRequest.indexName = followerIndex
+            return stopIndexReplicationRequest
+        }
+        private val log = LogManager.getLogger(StopIndexReplicationRequest::class.java)
+    }
+
+    override fun validate(): ActionRequestValidationException? {
+        return null
+    }
+
+    override fun indices(vararg indices: String?): IndicesRequest {
+        return this
+    }
+    override fun indices(): Array<String> {
+        return arrayOf(indexName)
+    }
+
+    override fun indicesOptions(): IndicesOptions {
+        return IndicesOptions.strictSingleIndexNoExpandForbidClosed()
+    }
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        builder.field("indexName", indexName)
+        builder.endObject()
+        return builder
+    }
+
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeString(indexName)
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/replication/ReplicationPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/replication/ReplicationPluginInterfaceTests.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.replication
+
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Answers
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.opensearch.action.ActionType
+import org.opensearch.action.support.master.AcknowledgedResponse
+import org.opensearch.client.node.NodeClient
+import org.opensearch.commons.replication.action.StopIndexReplicationRequest
+import org.opensearch.core.action.ActionListener
+
+@Suppress("UNCHECKED_CAST")
+@ExtendWith(MockitoExtension::class)
+internal class ReplicationPluginInterfaceTests {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private lateinit var client: NodeClient
+    @Test
+    fun stopReplication() {
+        val request = Mockito.mock(StopIndexReplicationRequest::class.java)
+        val response = AcknowledgedResponse(true)
+        val listener: ActionListener<AcknowledgedResponse> =
+            Mockito.mock(ActionListener::class.java) as ActionListener<AcknowledgedResponse>
+
+        Mockito.doAnswer {
+            (it.getArgument(2) as ActionListener<AcknowledgedResponse>)
+                .onResponse(response)
+        }.whenever(client).execute(Mockito.any(ActionType::class.java), Mockito.any(), Mockito.any())
+
+        ReplicationPluginInterface.stopReplication(client, request, listener)
+        Mockito.verify(listener, Mockito.times(1)).onResponse(ArgumentMatchers.eq(response))
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/replication/action/StopIndexReplicationRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/replication/action/StopIndexReplicationRequestTests.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.commons.replication.action
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.utils.recreateObject
+
+internal class StopIndexReplicationRequestTests {
+    @Test
+    fun `Stop Replication request serialize and deserialize transport object should be equal`() {
+        val index = "test-idx"
+        val request = StopIndexReplicationRequest(index)
+        val recreatedRequest = recreateObject(request) { StopIndexReplicationRequest(it) }
+        assertNotNull(recreatedRequest)
+        assertEquals(request.indexName, recreatedRequest.indexName)
+        assertNull(recreatedRequest.validate())
+    }
+}


### PR DESCRIPTION
### Description
**Background:**

- This change is required for a new feature being added in ism plugin -  [unfollow-action #726](https://github.com/opensearch-project/index-management/issues/726) - integrating ccr and ism plugins.
- For this feature, **ism plugin needs to invoke stop-replication action from ccr.** As both ccr and ism need to invoke some common code, the **common code can be moved to common-utils**, as done previously for other plugins too. For ex. [notifications plugin](https://github.com/opensearch-project/common-utils/pull/31/files)
- As sharing of libraries also leads to a type-cast and class-loading issue - previously seen with [notification plugin](https://github.com/opensearch-project/notifications/pull/223) - the request object needs to be of a higher-level class from opensearch-core like **ActionRequest** and later be recreated into required type i.e. **StopIndexReplicationRequest**.

**Proposed Solution:**
1. Common-utils: Move common code of stop-replication from ccr project to common-utils.
2. CCR: Modify ccr plugin to consume classes from common-utils. Also, create a new TransportAction that transforms the request into required type and invokes TransportStopIndexReplicationAction. 
3. ISM: Add new action in ism
(FYI - This is an alternative approach for this feature. I had also raised a [draft PR](https://github.com/opensearch-project/OpenSearch/pull/13615) with a different approach, but we didnt go ahead with it as it required changes in opensearch-core as well.)

**Change description:**
Code for StopIndexReplicationRequest and StopIndexReplicationAction are moved to common-utils. Added UTs for both the new classes added.
This PR caters to point 1 of the proposed solution.


### Issues Resolved
Related Issues
[unfollow-action #726](https://github.com/opensearch-project/index-management/issues/726)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- ~[ ] New functionality has been documented.~
  - ~[ ] New functionality has javadoc added~
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
