### PR TITLE
[Backport 2.x] Fixing DataSources Parsing Errors (#678)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DataSources.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DataSources.kt
@@ -31,6 +31,12 @@ data class DataSources(
     /** Configures a custom index pattern for alertHistoryIndex alias.*/
     val alertsHistoryIndexPattern: String? = "<.opendistro-alerting-alert-history-{now/d}-1>", // AlertIndices.ALERT_HISTORY_INDEX_PATTERN
 
+    /** Configures a custom index alias to store comments associated with alerts.*/
+    val commentsIndex: String? = DEFAULT_COMMENTS_INDEX, // CommentsIndices.COMMENTS_HISTORY_WRITE_INDEX
+
+    /** Configures a custom index pattern for commentsIndex alias.*/
+    val commentsIndexPattern: String? = DEFAULT_COMMENTS_INDEX_PATTERN, // CommentsIndices.COMMENTS_HISTORY_INDEX_PATTERN
+
     /** Configures custom mappings by field type for query index.
      * Custom query index mappings are configurable, only if a custom query index is configured too. */
     val queryIndexMappingsByType: Map<String, Map<String, String>> = mapOf(),
@@ -78,6 +84,28 @@ data class DataSources(
         findingsEnabled = sin.readOptionalBoolean()
     )
 
+    constructor(
+        queryIndex: String,
+        findingsIndex: String,
+        findingsIndexPattern: String?,
+        alertsIndex: String,
+        alertsHistoryIndex: String?,
+        alertsHistoryIndexPattern: String?,
+        queryIndexMappingsByType: Map<String, Map<String, String>>,
+        findingsEnabled: Boolean?
+    ) : this(
+        queryIndex = queryIndex,
+        findingsIndex = findingsIndex,
+        findingsIndexPattern = findingsIndexPattern,
+        alertsIndex = alertsIndex,
+        alertsHistoryIndex = alertsHistoryIndex,
+        alertsHistoryIndexPattern = alertsHistoryIndexPattern,
+        commentsIndex = DEFAULT_COMMENTS_INDEX,
+        commentsIndexPattern = DEFAULT_COMMENTS_INDEX_PATTERN,
+        queryIndexMappingsByType = queryIndexMappingsByType,
+        findingsEnabled = findingsEnabled
+    )
+
     @Suppress("UNCHECKED_CAST")
     fun asTemplateArg(): Map<String, Any?> {
         return mapOf(
@@ -115,6 +143,9 @@ data class DataSources(
         const val ALERTS_HISTORY_INDEX_PATTERN_FIELD = "alerts_history_index_pattern"
         const val QUERY_INDEX_MAPPINGS_BY_TYPE = "query_index_mappings_by_type"
         const val FINDINGS_ENABLED_FIELD = "findings_enabled"
+
+        const val DEFAULT_COMMENTS_INDEX = ".opensearch-alerting-comments-history-write"
+        const val DEFAULT_COMMENTS_INDEX_PATTERN = "<.opensearch-alerting-comments-history-{now/d}-1>"
 
         @JvmStatic
         @Throws(IOException::class)

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -489,4 +489,23 @@ class XContentTests {
 
         assertEquals("Round tripping alert doesn't work", actionExecutionResult, parsedActionExecutionResultString)
     }
+
+    @Test
+    fun `test DataSources parsing`() {
+        val dataSources = DataSources(
+            ScheduledJob.DOC_LEVEL_QUERIES_INDEX,
+            ".opensearch-alerting-finding-history-write",
+            "<.opensearch-alerting-finding-history-{now/d}-1>",
+            ".opendistro-alerting-alerts",
+            ".opendistro-alerting-alert-history-write",
+            "<.opendistro-alerting-alert-history-{now/d}-1>",
+            mapOf(),
+            false
+        )
+        Assertions.assertNotNull(dataSources)
+
+        val dataSourcesString = dataSources.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedDataSources = DataSources.parse(parser(dataSourcesString))
+        Assertions.assertEquals(dataSources, parsedDataSources, "Round tripping DataSources doesn't work")
+    }
 }


### PR DESCRIPTION
* attempt to fix DataSources breaking change

Signed-off-by: Dennis Toepker <toepkerd@amazon.com>

* adding default comments index values instead of passing null into constructor

Signed-off-by: Dennis Toepker <toepkerd@amazon.com>

---------

Signed-off-by: Dennis Toepker <toepkerd@amazon.com>
Co-authored-by: Dennis Toepker <toepkerd@amazon.com>
(cherry picked from commit f4b2e1b9de2b660b66815610b214ffd1f4ec579c)

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
