### PR TITLE
[Backport 2.x] Adding EntityType to Comment Model (#671)

### DIFF
--- a/release-notes/opensearch-common-utils.release-notes-2.15.0.0.md
+++ b/release-notes/opensearch-common-utils.release-notes-2.15.0.0.md
@@ -7,6 +7,7 @@ Compatible with OpenSearch 2.15.0
 
 ### Enhancements
 * Add start_time and end_time filters to GetAlertsRequest. ([#655](https://github.com/opensearch-project/common-utils/pull/655))
+* Added new models for Alerting Comments ([#663](https://github.com/opensearch-project/common-utils/pull/663), [#671](https://github.com/opensearch-project/common-utils/pull/671), [#674](https://github.com/opensearch-project/common-utils/pull/674) [#678](https://github.com/opensearch-project/common-utils/pull/678))
 
 ### Documentation
 * Added 2.15.0.0 release notes. ([#672](https://github.com/opensearch-project/common-utils/pull/672))

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexCommentRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexCommentRequest.kt
@@ -18,6 +18,7 @@ import java.io.IOException
  */
 class IndexCommentRequest : ActionRequest {
     val entityId: String
+    val entityType: String
     val commentId: String
     val seqNo: Long
     val primaryTerm: Long
@@ -26,6 +27,7 @@ class IndexCommentRequest : ActionRequest {
 
     constructor(
         entityId: String,
+        entityType: String,
         commentId: String,
         seqNo: Long,
         primaryTerm: Long,
@@ -33,6 +35,7 @@ class IndexCommentRequest : ActionRequest {
         content: String
     ) : super() {
         this.entityId = entityId
+        this.entityType = entityType
         this.commentId = commentId
         this.seqNo = seqNo
         this.primaryTerm = primaryTerm
@@ -43,6 +46,7 @@ class IndexCommentRequest : ActionRequest {
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         entityId = sin.readString(),
+        entityType = sin.readString(),
         commentId = sin.readString(),
         seqNo = sin.readLong(),
         primaryTerm = sin.readLong(),
@@ -64,6 +68,7 @@ class IndexCommentRequest : ActionRequest {
     @Throws(IOException::class)
     override fun writeTo(out: StreamOutput) {
         out.writeString(entityId)
+        out.writeString(entityType)
         out.writeString(commentId)
         out.writeLong(seqNo)
         out.writeLong(primaryTerm)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Comment.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Comment.kt
@@ -19,16 +19,17 @@ import java.time.Instant
 data class Comment(
     val id: String = NO_ID,
     val entityId: String = NO_ID,
+    val entityType: String,
     val content: String,
     val createdTime: Instant,
     val lastUpdatedTime: Instant?,
     val user: User?
 ) : Writeable, ToXContent {
-
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         id = sin.readString(),
         entityId = sin.readString(),
+        entityType = sin.readString(),
         content = sin.readString(),
         createdTime = sin.readInstant(),
         lastUpdatedTime = sin.readOptionalInstant(),
@@ -37,11 +38,13 @@ data class Comment(
 
     constructor(
         entityId: String,
+        entityType: String,
         content: String,
         createdTime: Instant,
         user: User?
     ) : this (
         entityId = entityId,
+        entityType = entityType,
         content = content,
         createdTime = createdTime,
         lastUpdatedTime = null,
@@ -52,6 +55,7 @@ data class Comment(
     override fun writeTo(out: StreamOutput) {
         out.writeString(id)
         out.writeString(entityId)
+        out.writeString(entityType)
         out.writeString(content)
         out.writeInstant(createdTime)
         out.writeOptionalInstant(lastUpdatedTime)
@@ -63,6 +67,7 @@ data class Comment(
         return mapOf<String, Any?>(
             _ID to id,
             ENTITY_ID_FIELD to entityId,
+            ENTITY_TYPE_FIELD to entityType,
             COMMENT_CONTENT_FIELD to content,
             COMMENT_CREATED_TIME_FIELD to createdTime,
             COMMENT_LAST_UPDATED_TIME_FIELD to lastUpdatedTime,
@@ -83,6 +88,7 @@ data class Comment(
     private fun createXContentBuilder(builder: XContentBuilder, includeFullUser: Boolean): XContentBuilder {
         builder.startObject()
             .field(ENTITY_ID_FIELD, entityId)
+            .field(ENTITY_TYPE_FIELD, entityType)
             .field(COMMENT_CONTENT_FIELD, content)
             .optionalTimeField(COMMENT_CREATED_TIME_FIELD, createdTime)
             .optionalTimeField(COMMENT_LAST_UPDATED_TIME_FIELD, lastUpdatedTime)
@@ -101,6 +107,7 @@ data class Comment(
 
     companion object {
         const val ENTITY_ID_FIELD = "entity_id"
+        const val ENTITY_TYPE_FIELD = "entity_type"
         const val COMMENT_CONTENT_FIELD = "content"
         const val COMMENT_CREATED_TIME_FIELD = "created_time"
         const val COMMENT_LAST_UPDATED_TIME_FIELD = "last_updated_time"
@@ -112,6 +119,7 @@ data class Comment(
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, id: String = NO_ID): Comment {
             lateinit var entityId: String
+            lateinit var entityType: String
             var content = ""
             lateinit var createdTime: Instant
             var lastUpdatedTime: Instant? = null
@@ -124,6 +132,7 @@ data class Comment(
 
                 when (fieldName) {
                     ENTITY_ID_FIELD -> entityId = xcp.text()
+                    ENTITY_TYPE_FIELD -> entityType = xcp.text()
                     COMMENT_CONTENT_FIELD -> content = xcp.text()
                     COMMENT_CREATED_TIME_FIELD -> createdTime = requireNotNull(xcp.instant())
                     COMMENT_LAST_UPDATED_TIME_FIELD -> lastUpdatedTime = xcp.instant()
@@ -139,6 +148,7 @@ data class Comment(
             return Comment(
                 id = id,
                 entityId = entityId,
+                entityType = entityType,
                 content = content,
                 createdTime = createdTime,
                 lastUpdatedTime = lastUpdatedTime,

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexCommentRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexCommentRequestTests.kt
@@ -10,13 +10,14 @@ import org.opensearch.rest.RestRequest
 class IndexCommentRequestTests {
     @Test
     fun `test index comment post request`() {
-        val req = IndexCommentRequest("123", "456", 1L, 2L, RestRequest.Method.POST, "comment")
+        val req = IndexCommentRequest("123", "alert", "456", 1L, 2L, RestRequest.Method.POST, "comment")
         assertNotNull(req)
         val out = BytesStreamOutput()
         req.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newReq = IndexCommentRequest(sin)
         assertEquals("123", newReq.entityId)
+        assertEquals("alert", newReq.entityType)
         assertEquals("456", newReq.commentId)
         assertEquals(1L, newReq.seqNo)
         assertEquals(2L, newReq.primaryTerm)
@@ -26,13 +27,14 @@ class IndexCommentRequestTests {
 
     @Test
     fun `test index comment put request`() {
-        val req = IndexCommentRequest("123", "456", 1L, 2L, RestRequest.Method.PUT, "comment")
+        val req = IndexCommentRequest("123", "alert", "456", 1L, 2L, RestRequest.Method.PUT, "comment")
         assertNotNull(req)
         val out = BytesStreamOutput()
         req.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
         val newReq = IndexCommentRequest(sin)
         assertEquals("123", newReq.entityId)
+        assertEquals("alert", newReq.entityType)
         assertEquals("456", newReq.commentId)
         assertEquals(1L, newReq.seqNo)
         assertEquals(2L, newReq.primaryTerm)

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/IndexCommentResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/IndexCommentResponseTests.kt
@@ -13,6 +13,7 @@ class IndexCommentResponseTests {
     fun `test index comment response with comment`() {
         val comment = Comment(
             "123",
+            "alert",
             "456",
             "comment",
             Instant.now(),

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -20,6 +20,7 @@ import org.opensearch.commons.alerting.randomUserEmpty
 import org.opensearch.commons.authuser.User
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.search.builder.SearchSourceBuilder
+import java.time.Instant
 import kotlin.test.assertTrue
 
 class WriteableTests {
@@ -189,5 +190,31 @@ class WriteableTests {
             newActionExecutionPolicy,
             "Round tripping ActionExecutionPolicy doesn't work"
         )
+    }
+
+    @Test
+    fun `test Comment object`() {
+        val user = randomUser()
+        val createdTime = Instant.now()
+        val comment = Comment(
+            "123",
+            "456",
+            "alert",
+            "content",
+            createdTime,
+            null,
+            user
+        )
+        Assertions.assertNotNull(comment)
+        val out = BytesStreamOutput()
+        comment.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newComment = Comment(sin)
+        Assertions.assertEquals("123", newComment.id)
+        Assertions.assertEquals("456", newComment.entityId)
+        Assertions.assertEquals("alert", newComment.entityType)
+        Assertions.assertEquals("content", newComment.content)
+        Assertions.assertEquals(createdTime, newComment.createdTime)
+        Assertions.assertEquals(user, newComment.user)
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -525,4 +525,22 @@ class XContentTests {
         val parsedDataSources = DataSources.parse(parser(dataSourcesString))
         Assertions.assertEquals(dataSources, parsedDataSources, "Round tripping DataSources doesn't work")
     }
+
+    @Test
+    fun `test Comment parsing`() {
+        val comment = Comment(
+            "123",
+            "456",
+            "alert",
+            "content",
+            Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            null,
+            randomUser()
+        )
+        Assertions.assertNotNull(comment)
+
+        val commentString = comment.toXContentWithUser(builder()).string()
+        val parsedComment = Comment.parse(parser(commentString), "123")
+        Assertions.assertEquals(comment, parsedComment, "Round tripping Comment doesn't work")
+    }
 }


### PR DESCRIPTION
* adding entityType to Comment model



* updated tests



* removing EntityType enum class, entity type in documents will just be strings



* fixed unit tests



* adding tests and release notes



* moved comment test to WriteableTests



* updated writeable test



---------

### Description
Manual backport to 2.x of PR #671 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
