### PR TITLE
Update PULL_REQUEST_TEMPLATE to include an API spec change in the checklist.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,16 @@
 ### Description
 [Describe what this change achieves]
- 
-### Issues Resolved
-[List any issues this PR will resolve]
- 
+
+### Related Issues
+Resolves #[Issue number to be closed when this PR is merged]
+<!-- List any other related issues here -->
+
 ### Check List
 - [ ] New functionality includes testing.
-  - [ ] All tests pass
 - [ ] New functionality has been documented.
-  - [ ] New functionality has javadoc added
-- [ ] Commits are signed per the DCO using --signoff 
+- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
+- [ ] Commits are signed per the DCO using `--signoff`.
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/opensearch-api-specification/issues/387, update PR template to include a checkbox that requests that all API changes be documented in the OpenAPI spec used to generate clients.