### PR TITLE
[Backport 2.9] add missing ctx variables (#710)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/BucketLevelTrigger.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/BucketLevelTrigger.kt
@@ -69,7 +69,13 @@ data class BucketLevelTrigger(
             NAME_FIELD to name,
             SEVERITY_FIELD to severity,
             ACTIONS_FIELD to actions.map { it.asTemplateArg() },
-            PARENT_BUCKET_PATH to getParentBucketPath()
+            PARENT_BUCKET_PATH to getParentBucketPath(),
+            CONDITION_FIELD to mapOf(
+                SCRIPT_FIELD to mapOf(
+                    SOURCE_FIELD to bucketSelector.script.idOrCode,
+                    LANG_FIELD to bucketSelector.script.lang
+                )
+            )
         )
     }
 
@@ -81,6 +87,9 @@ data class BucketLevelTrigger(
         const val BUCKET_LEVEL_TRIGGER_FIELD = "bucket_level_trigger"
         const val CONDITION_FIELD = "condition"
         const val PARENT_BUCKET_PATH = "parentBucketPath"
+        const val SCRIPT_FIELD = "script"
+        const val SOURCE_FIELD = "source"
+        const val LANG_FIELD = "lang"
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
             Trigger::class.java,

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
@@ -24,7 +24,7 @@ data class DocLevelMonitorInput(
         sin.readList(::DocLevelQuery) // docLevelQueries
     )
 
-    fun asTemplateArg(): Map<String, Any?> {
+    override fun asTemplateArg(): Map<String, Any> {
         return mapOf(
             DESCRIPTION_FIELD to description,
             INDICES_FIELD to indices,

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocumentLevelTrigger.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocumentLevelTrigger.kt
@@ -60,7 +60,13 @@ data class DocumentLevelTrigger(
             ID_FIELD to id,
             NAME_FIELD to name,
             SEVERITY_FIELD to severity,
-            ACTIONS_FIELD to actions.map { it.asTemplateArg() }
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() },
+            CONDITION_FIELD to mapOf(
+                SCRIPT_FIELD to mapOf(
+                    SOURCE_FIELD to condition.idOrCode,
+                    LANG_FIELD to condition.lang
+                )
+            )
         )
     }
 
@@ -78,6 +84,8 @@ data class DocumentLevelTrigger(
         const val CONDITION_FIELD = "condition"
         const val SCRIPT_FIELD = "script"
         const val QUERY_IDS_FIELD = "query_ids"
+        const val SOURCE_FIELD = "source"
+        const val LANG_FIELD = "lang"
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
             Trigger::class.java,

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Input.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Input.kt
@@ -54,4 +54,7 @@ interface Input : BaseModel {
     }
 
     fun name(): String
+
+    /** Returns a representation of the schedule suitable for passing into painless and mustache scripts. */
+    fun asTemplateArg(): Map<String, Any> = emptyMap()
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -124,8 +124,18 @@ data class Monitor(
     }
 
     /** Returns a representation of the monitor suitable for passing into painless and mustache scripts. */
-    fun asTemplateArg(): Map<String, Any> {
-        return mapOf(_ID to id, _VERSION to version, NAME_FIELD to name, ENABLED_FIELD to enabled)
+    fun asTemplateArg(): Map<String, Any?> {
+        return mapOf(
+            _ID to id,
+            _VERSION to version,
+            NAME_FIELD to name,
+            ENABLED_FIELD to enabled,
+            MONITOR_TYPE_FIELD to monitorType.toString(),
+            ENABLED_TIME_FIELD to enabledTime?.toEpochMilli(),
+            LAST_UPDATE_TIME_FIELD to lastUpdateTime.toEpochMilli(),
+            SCHEDULE_FIELD to schedule.asTemplateArg(),
+            INPUTS_FIELD to inputs.map { it.asTemplateArg() }
+        )
     }
 
     fun toXContentWithUser(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/QueryLevelTrigger.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/QueryLevelTrigger.kt
@@ -60,7 +60,13 @@ data class QueryLevelTrigger(
             ID_FIELD to id,
             NAME_FIELD to name,
             SEVERITY_FIELD to severity,
-            ACTIONS_FIELD to actions.map { it.asTemplateArg() }
+            ACTIONS_FIELD to actions.map { it.asTemplateArg() },
+            CONDITION_FIELD to mapOf(
+                SCRIPT_FIELD to mapOf(
+                    SOURCE_FIELD to condition.idOrCode,
+                    LANG_FIELD to condition.lang
+                )
+            )
         )
     }
 
@@ -77,6 +83,8 @@ data class QueryLevelTrigger(
         const val QUERY_LEVEL_TRIGGER_FIELD = "query_level_trigger"
         const val CONDITION_FIELD = "condition"
         const val SCRIPT_FIELD = "script"
+        const val SOURCE_FIELD = "source"
+        const val LANG_FIELD = "lang"
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
             Trigger::class.java,

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Schedule.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Schedule.kt
@@ -146,6 +146,9 @@ sealed class Schedule : BaseModel {
     abstract fun getPeriodEndingAt(endTime: Instant?): Pair<Instant, Instant>
 
     abstract fun runningOnTime(lastExecutionTime: Instant?): Boolean
+
+    /** Returns a representation of the schedule suitable for passing into painless and mustache scripts. */
+    abstract fun asTemplateArg(): Map<String, Any>
 }
 
 /**
@@ -257,6 +260,14 @@ data class CronSchedule(
         out.writeString(expression)
         out.writeZoneId(timezone)
     }
+
+    override fun asTemplateArg(): Map<String, Any> =
+        mapOf(
+            CRON_FIELD to mapOf(
+                EXPRESSION_FIELD to expression,
+                TIMEZONE_FIELD to timezone.toString()
+            )
+        )
 }
 
 data class IntervalSchedule(
@@ -354,4 +365,12 @@ data class IntervalSchedule(
         out.writeInt(interval)
         out.writeEnum(unit)
     }
+
+    override fun asTemplateArg(): Map<String, Any> =
+        mapOf(
+            PERIOD_FIELD to mapOf(
+                INTERVAL_FIELD to interval,
+                UNIT_FIELD to unit.toString()
+            )
+        )
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/SearchInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/SearchInput.kt
@@ -85,4 +85,12 @@ data class SearchInput(val indices: List<String>, val query: SearchSourceBuilder
             return SearchInput(sin)
         }
     }
+
+    override fun asTemplateArg(): Map<String, Any> =
+        mapOf(
+            SEARCH_FIELD to mapOf(
+                INDICES_FIELD to indices,
+                QUERY_FIELD to query.toString()
+            )
+        )
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/action/Action.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/action/Action.kt
@@ -65,7 +65,12 @@ data class Action(
     }
 
     fun asTemplateArg(): Map<String, Any> {
-        return mapOf(NAME_FIELD to name)
+        return mapOf(
+            ID_FIELD to id,
+            NAME_FIELD to name,
+            DESTINATION_ID_FIELD to destinationId,
+            THROTTLE_ENABLED_FIELD to throttleEnabled
+        )
     }
 
     @Throws(IOException::class)

--- a/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/TestHelpers.kt
@@ -394,6 +394,13 @@ fun randomDocLevelMonitorInput(
     return DocLevelMonitorInput(description = description, indices = indices, queries = queries)
 }
 
+fun randomSearchInput(
+    indices: List<String> = listOf(1..RandomNumbers.randomIntBetween(Random(), 0, 10)).map { RandomStrings.randomAsciiLettersOfLength(Random(), 10) },
+    query: SearchSourceBuilder = SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
+): SearchInput {
+    return SearchInput(indices, query)
+}
+
 fun randomClusterMetricsInput(
     path: String = ClusterMetricsInput.ClusterMetricType.values()
         .filter { it.defaultPath.isNotBlank() && !it.requiresPathParams }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/BucketLevelTriggerTests.kt
@@ -1,0 +1,54 @@
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.BucketLevelTrigger.Companion.CONDITION_FIELD
+import org.opensearch.commons.alerting.model.BucketLevelTrigger.Companion.LANG_FIELD
+import org.opensearch.commons.alerting.model.BucketLevelTrigger.Companion.PARENT_BUCKET_PATH
+import org.opensearch.commons.alerting.model.BucketLevelTrigger.Companion.SCRIPT_FIELD
+import org.opensearch.commons.alerting.model.BucketLevelTrigger.Companion.SOURCE_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ID_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.NAME_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import org.opensearch.commons.alerting.randomBucketLevelTrigger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BucketLevelTriggerTests {
+
+    @Test
+    fun `test BucketLevelTrigger asTemplateArgs`() {
+        val trigger = randomBucketLevelTrigger()
+
+        val templateArgs = trigger.asTemplateArg()
+
+        assertEquals(trigger.id, templateArgs[ID_FIELD], "Template arg field 'id' doesn't match")
+        assertEquals(trigger.name, templateArgs[NAME_FIELD], "Template arg field 'name' doesn't match")
+        assertEquals(trigger.severity, templateArgs[SEVERITY_FIELD], "Template arg field 'severity' doesn't match")
+        val actions = templateArgs[ACTIONS_FIELD] as List<*>
+        assertEquals(
+            trigger.actions.size,
+            actions.size,
+            "Template arg field 'actions' doesn't match"
+        )
+        assertEquals(
+            trigger.getParentBucketPath(),
+            templateArgs[PARENT_BUCKET_PATH],
+            "Template arg field 'parentBucketPath' doesn't match"
+        )
+        val condition = templateArgs[CONDITION_FIELD] as? Map<*, *>
+        assertNotNull(condition, "Template arg field 'condition' is empty")
+        val script = condition[SCRIPT_FIELD] as? Map<*, *>
+        assertNotNull(script, "Template arg field 'condition.script' is empty")
+        assertEquals(
+            trigger.bucketSelector.script.idOrCode,
+            script[SOURCE_FIELD],
+            "Template arg field 'script.source' doesn't match"
+        )
+        assertEquals(
+            trigger.bucketSelector.script.lang,
+            script[LANG_FIELD],
+            "Template arg field 'script.lang' doesn't match"
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/DocumentLevelTriggerTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/DocumentLevelTriggerTests.kt
@@ -1,0 +1,48 @@
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.DocumentLevelTrigger.Companion.CONDITION_FIELD
+import org.opensearch.commons.alerting.model.DocumentLevelTrigger.Companion.LANG_FIELD
+import org.opensearch.commons.alerting.model.DocumentLevelTrigger.Companion.SCRIPT_FIELD
+import org.opensearch.commons.alerting.model.DocumentLevelTrigger.Companion.SOURCE_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ID_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.NAME_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import org.opensearch.commons.alerting.randomDocumentLevelTrigger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class DocumentLevelTriggerTests {
+
+    @Test
+    fun `test DocumentLevelTrigger asTemplateArgs`() {
+        val trigger = randomDocumentLevelTrigger()
+
+        val templateArgs = trigger.asTemplateArg()
+
+        assertEquals(trigger.id, templateArgs[ID_FIELD], "Template arg field 'id' doesn't match")
+        assertEquals(trigger.name, templateArgs[NAME_FIELD], "Template arg field 'name' doesn't match")
+        assertEquals(trigger.severity, templateArgs[SEVERITY_FIELD], "Template arg field 'severity' doesn't match")
+        val actions = templateArgs[ACTIONS_FIELD] as List<*>
+        assertEquals(
+            trigger.actions.size,
+            actions.size,
+            "Template arg field 'actions' doesn't match"
+        )
+        val condition = templateArgs[CONDITION_FIELD] as? Map<*, *>
+        assertNotNull(condition, "Template arg field 'condition' is empty")
+        val script = condition[SCRIPT_FIELD] as? Map<*, *>
+        assertNotNull(script, "Template arg field 'condition.script' is empty")
+        assertEquals(
+            trigger.condition.idOrCode,
+            script[SOURCE_FIELD],
+            "Template arg field 'script.source' doesn't match"
+        )
+        assertEquals(
+            trigger.condition.lang,
+            script[LANG_FIELD],
+            "Template arg field 'script.lang' doesn't match"
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/MonitorsTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/MonitorsTests.kt
@@ -1,0 +1,49 @@
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.randomQueryLevelMonitor
+import org.opensearch.commons.alerting.util.IndexUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MonitorsTests {
+
+    @Test
+    fun `test monitor asTemplateArgs`() {
+        val monitor = randomQueryLevelMonitor(enabled = true)
+
+        val templateArgs = monitor.asTemplateArg()
+
+        assertEquals(monitor.id, templateArgs[IndexUtils._ID], "Template arg field 'id' doesn't match")
+        assertEquals(
+            monitor.version,
+            templateArgs[IndexUtils._VERSION],
+            "Template arg field 'version' doesn't match"
+        )
+        assertEquals(monitor.name, templateArgs[Monitor.NAME_FIELD], "Template arg field 'name' doesn't match")
+        assertEquals(
+            monitor.enabled,
+            templateArgs[Monitor.ENABLED_FIELD],
+            "Template arg field 'enabled' doesn't match"
+        )
+        assertEquals(
+            monitor.monitorType.toString(),
+            templateArgs[Monitor.MONITOR_TYPE_FIELD],
+            "Template arg field 'monitoryType' doesn't match"
+        )
+        assertEquals(
+            monitor.enabledTime?.toEpochMilli(),
+            templateArgs[Monitor.ENABLED_TIME_FIELD],
+            "Template arg field 'enabledTime' doesn't match"
+        )
+        assertEquals(
+            monitor.lastUpdateTime.toEpochMilli(),
+            templateArgs[Monitor.LAST_UPDATE_TIME_FIELD],
+            "Template arg field 'lastUpdateTime' doesn't match"
+        )
+        assertNotNull(templateArgs[Monitor.SCHEDULE_FIELD], "Template arg field 'schedule' not set")
+        val inputs = templateArgs[Monitor.INPUTS_FIELD] as? List<*>
+        assertNotNull(inputs, "Template arg field 'inputs' not set")
+        assertEquals(1, inputs.size, "Template arg field 'inputs' is not populated")
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/QueryLevelTriggerTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/QueryLevelTriggerTests.kt
@@ -1,0 +1,48 @@
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.QueryLevelTrigger.Companion.CONDITION_FIELD
+import org.opensearch.commons.alerting.model.QueryLevelTrigger.Companion.LANG_FIELD
+import org.opensearch.commons.alerting.model.QueryLevelTrigger.Companion.SCRIPT_FIELD
+import org.opensearch.commons.alerting.model.QueryLevelTrigger.Companion.SOURCE_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ACTIONS_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.ID_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.NAME_FIELD
+import org.opensearch.commons.alerting.model.Trigger.Companion.SEVERITY_FIELD
+import org.opensearch.commons.alerting.randomQueryLevelTrigger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class QueryLevelTriggerTests {
+
+    @Test
+    fun `test QueryLevelTrigger asTemplateArgs`() {
+        val trigger = randomQueryLevelTrigger()
+
+        val templateArgs = trigger.asTemplateArg()
+
+        assertEquals(trigger.id, templateArgs[ID_FIELD], "Template arg field 'id' doesn't match")
+        assertEquals(trigger.name, templateArgs[NAME_FIELD], "Template arg field 'name' doesn't match")
+        assertEquals(trigger.severity, templateArgs[SEVERITY_FIELD], "Template arg field 'severity' doesn't match")
+        val actions = templateArgs[ACTIONS_FIELD] as List<*>
+        assertEquals(
+            trigger.actions.size,
+            actions.size,
+            "Template arg field 'actions' doesn't match"
+        )
+        val condition = templateArgs[CONDITION_FIELD] as? Map<*, *>
+        assertNotNull(condition, "Template arg field 'condition' is empty")
+        val script = condition[SCRIPT_FIELD] as? Map<*, *>
+        assertNotNull(script, "Template arg field 'condition.script' is empty")
+        assertEquals(
+            trigger.condition.idOrCode,
+            script[SOURCE_FIELD],
+            "Template arg field 'script.source' doesn't match"
+        )
+        assertEquals(
+            trigger.condition.lang,
+            script[LANG_FIELD],
+            "Template arg field 'script.lang' doesn't match"
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleTest.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleTest.kt
@@ -1,6 +1,12 @@
 package org.opensearch.commons.alerting.model
 
 import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.Schedule.Companion.CRON_FIELD
+import org.opensearch.commons.alerting.model.Schedule.Companion.EXPRESSION_FIELD
+import org.opensearch.commons.alerting.model.Schedule.Companion.INTERVAL_FIELD
+import org.opensearch.commons.alerting.model.Schedule.Companion.PERIOD_FIELD
+import org.opensearch.commons.alerting.model.Schedule.Companion.TIMEZONE_FIELD
+import org.opensearch.commons.alerting.model.Schedule.Companion.UNIT_FIELD
 import org.opensearch.commons.alerting.util.string
 import org.opensearch.core.xcontent.ToXContent
 import java.time.Instant
@@ -67,7 +73,8 @@ class ScheduleTest : XContentTestBase {
 
         val cronSchedule = CronSchedule(cronExpression, ZoneId.of("America/Los_Angeles"))
         // The nextTimeToExecute should be the minute after the previous execution time instance, not enabledTimeInstance
-        val nextTimeToExecute = cronSchedule.getExpectedNextExecutionTime(enabledTimeInstance, previousExecutionTimeInstance)
+        val nextTimeToExecute =
+            cronSchedule.getExpectedNextExecutionTime(enabledTimeInstance, previousExecutionTimeInstance)
         assertNotNull(nextTimeToExecute, "There should be next execute time")
         assertEquals(
             previousExecutionTimeInstance.plusSeconds(2L),
@@ -107,7 +114,8 @@ class ScheduleTest : XContentTestBase {
         val intervalSchedule = IntervalSchedule(1, ChronoUnit.MINUTES, testInstance)
 
         // The nextTimeToExecute should be the minute after the previous execution time instance
-        val nextTimeToExecute = intervalSchedule.getExpectedNextExecutionTime(enabledTimeInstance, previousExecutionTimeInstance)
+        val nextTimeToExecute =
+            intervalSchedule.getExpectedNextExecutionTime(enabledTimeInstance, previousExecutionTimeInstance)
         assertNotNull(nextTimeToExecute, "There should be next execute time")
         assertEquals(
             previousExecutionTimeInstance.plusSeconds(60L),
@@ -165,12 +173,19 @@ class ScheduleTest : XContentTestBase {
     @Test
     fun `test invalid type`() {
         val scheduleString = "{\"foobarzzz\":{\"expression\":\"0 * * * *\",\"timezone\":\"+++9\"}}"
-        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") { Schedule.parse(parser(scheduleString)) }
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
+            Schedule.parse(
+                parser(
+                    scheduleString
+                )
+            )
+        }
     }
 
     @Test
     fun `test two types`() {
-        val scheduleString = "{\"cron\":{\"expression\":\"0 * * * *\",\"timezone\":\"Asia/Tokyo\"}, \"period\":{\"interval\":\"1\",\"unit\":\"Minutes\"}}"
+        val scheduleString =
+            "{\"cron\":{\"expression\":\"0 * * * *\",\"timezone\":\"Asia/Tokyo\"}, \"period\":{\"interval\":\"1\",\"unit\":\"Minutes\"}}"
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
             Schedule.parse(parser(scheduleString))
         }
@@ -334,5 +349,45 @@ class ScheduleTest : XContentTestBase {
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException") {
             IntervalSchedule(-1, ChronoUnit.MINUTES)
         }
+    }
+
+    @Test
+    fun `test IntervalSchedule as asTemplateArgs`() {
+        val schedule = createTestIntervalSchedule()
+
+        val templateArgs = schedule.asTemplateArg()
+
+        val period = templateArgs[PERIOD_FIELD] as? Map<*, *>
+        assertNotNull(period, "Template arg field 'period' is empty")
+        assertEquals(
+            schedule.interval,
+            period[INTERVAL_FIELD],
+            "Template arg field 'interval' doesn't match"
+        )
+        assertEquals(
+            schedule.unit.toString(),
+            period[UNIT_FIELD],
+            "Template arg field 'unit' doesn't match"
+        )
+    }
+
+    @Test
+    fun `test CronSchedule as asTemplateArgs`() {
+        val schedule = createTestCronSchedule()
+
+        val templateArgs = schedule.asTemplateArg()
+
+        val cron = templateArgs[CRON_FIELD] as? Map<*, *>
+        assertNotNull(cron, "Template arg field 'cron' is empty")
+        assertEquals(
+            schedule.expression,
+            cron[EXPRESSION_FIELD],
+            "Template arg field 'expression' doesn't match"
+        )
+        assertEquals(
+            schedule.timezone.toString(),
+            cron[TIMEZONE_FIELD],
+            "Template arg field 'timezone' doesn't match"
+        )
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/SearchInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/SearchInputTests.kt
@@ -1,0 +1,32 @@
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.SearchInput.Companion.INDICES_FIELD
+import org.opensearch.commons.alerting.model.SearchInput.Companion.QUERY_FIELD
+import org.opensearch.commons.alerting.model.SearchInput.Companion.SEARCH_FIELD
+import org.opensearch.commons.alerting.randomSearchInput
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SearchInputTests {
+
+    @Test
+    fun `test SearchInput asTemplateArgs`() {
+        val searchInput = randomSearchInput()
+
+        val templateArgs = searchInput.asTemplateArg()
+
+        val search = templateArgs[SEARCH_FIELD] as? Map<*, *>
+        assertNotNull(search, "Template arg field 'search' is empty")
+        assertEquals(
+            searchInput.indices,
+            search[INDICES_FIELD],
+            "Template arg field 'indices' doesn't match"
+        )
+        assertEquals(
+            searchInput.query.toString(),
+            search[QUERY_FIELD],
+            "Template arg field 'query' doesn't match"
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/action/ActionTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/action/ActionTests.kt
@@ -1,0 +1,40 @@
+package org.opensearch.commons.alerting.model.action
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.model.action.Action.Companion.DESTINATION_ID_FIELD
+import org.opensearch.commons.alerting.model.action.Action.Companion.ID_FIELD
+import org.opensearch.commons.alerting.model.action.Action.Companion.NAME_FIELD
+import org.opensearch.commons.alerting.model.action.Action.Companion.THROTTLE_ENABLED_FIELD
+import org.opensearch.commons.alerting.randomAction
+
+class ActionTests {
+
+    @Test
+    fun `test action asTemplateArgs`() {
+        val action = randomAction()
+
+        val templateArgs = action.asTemplateArg()
+
+        assertEquals(
+            action.id,
+            templateArgs[ID_FIELD],
+            "Template arg field 'id' doesn't match"
+        )
+        assertEquals(
+            action.name,
+            templateArgs[NAME_FIELD],
+            "Template arg field 'name' doesn't match"
+        )
+        assertEquals(
+            action.destinationId,
+            templateArgs[DESTINATION_ID_FIELD],
+            "Template arg field 'destinationId' doesn't match"
+        )
+        assertEquals(
+            action.throttleEnabled,
+            templateArgs[THROTTLE_ENABLED_FIELD],
+            "Template arg field 'throttleEnabled' doesn't match"
+        )
+    }
+}


### PR DESCRIPTION
### Description
Backport #710 to 2.9
 
Ran security analytics and alerting tests locally with these changes. 

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
