### PR TITLE
changing the names of the alerting comment actions

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt
@@ -21,9 +21,9 @@ object AlertingActions {
     const val SUBSCRIBE_FINDINGS_ACTION_NAME = "cluster:admin/opensearch/alerting/findings/subscribe"
     const val GET_MONITOR_ACTION_NAME = "cluster:admin/opendistro/alerting/monitor/get"
     const val SEARCH_MONITORS_ACTION_NAME = "cluster:admin/opendistro/alerting/monitor/search"
-    const val INDEX_COMMENT_ACTION_NAME = "cluster:admin/opensearch/alerting/alerts/comments/write"
-    const val SEARCH_COMMENTS_ACTION_NAME = "cluster:admin/opensearch/alerting/alerts/comments/search"
-    const val DELETE_COMMENT_ACTION_NAME = "cluster:admin/opensearch/alerting/alerts/comments/delete"
+    const val INDEX_COMMENT_ACTION_NAME = "cluster:admin/opensearch/alerting/comments/write"
+    const val SEARCH_COMMENTS_ACTION_NAME = "cluster:admin/opensearch/alerting/comments/search"
+    const val DELETE_COMMENT_ACTION_NAME = "cluster:admin/opensearch/alerting/comments/delete"
 
     @JvmField
     val INDEX_MONITOR_ACTION_TYPE =


### PR DESCRIPTION
### Description
Modifying the alerting comments permissions to not be put under `alerting/alerts`. With the way `alerting_ack_alerts` is currently configured in Security plugin, putting comments permissions under `alerting/alerts` would give someone with `alerting_ack_alerts` role full access to alerting comments (including edit and delete)

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
