### PR TITLE
changes to support dynamic deletion of doc-level monitor query indices

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -42,6 +42,7 @@ data class Monitor(
     val triggers: List<Trigger>,
     val uiMetadata: Map<String, Any>,
     val dataSources: DataSources = DataSources(),
+    val deleteQueryIndexInEveryRun: Boolean? = false,
     val owner: String? = "alerting"
 ) : ScheduledJob {
 
@@ -110,6 +111,7 @@ data class Monitor(
         } else {
             DataSources()
         },
+        deleteQueryIndexInEveryRun = sin.readOptionalBoolean(),
         owner = sin.readOptionalString()
     )
 
@@ -169,6 +171,7 @@ data class Monitor(
             .optionalTimeField(LAST_UPDATE_TIME_FIELD, lastUpdateTime)
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
         builder.field(DATA_SOURCES_FIELD, dataSources)
+        builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
         builder.field(OWNER_FIELD, owner)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -220,6 +223,7 @@ data class Monitor(
         out.writeMap(uiMetadata)
         out.writeBoolean(dataSources != null) // for backward compatibility with pre-existing monitors which don't have datasources field
         dataSources.writeTo(out)
+        out.writeOptionalBoolean(deleteQueryIndexInEveryRun)
         out.writeOptionalString(owner)
     }
 
@@ -240,6 +244,7 @@ data class Monitor(
         const val UI_METADATA_FIELD = "ui_metadata"
         const val DATA_SOURCES_FIELD = "data_sources"
         const val ENABLED_TIME_FIELD = "enabled_time"
+        const val DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD = "delete_query_index_in_every_run"
         const val OWNER_FIELD = "owner"
         val MONITOR_TYPE_PATTERN = Pattern.compile("[a-zA-Z0-9_]{5,25}")
 
@@ -268,6 +273,7 @@ data class Monitor(
             val triggers: MutableList<Trigger> = mutableListOf()
             val inputs: MutableList<Input> = mutableListOf()
             var dataSources = DataSources()
+            var deleteQueryIndexInEveryRun = false
             var owner = "alerting"
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
@@ -321,6 +327,11 @@ data class Monitor(
                     } else {
                         DataSources.parse(xcp)
                     }
+                    DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD -> deleteQueryIndexInEveryRun = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        deleteQueryIndexInEveryRun
+                    } else {
+                        xcp.booleanValue()
+                    }
                     OWNER_FIELD -> owner = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) owner else xcp.text()
                     else -> {
                         xcp.skipChildren()
@@ -348,6 +359,7 @@ data class Monitor(
                 triggers.toList(),
                 uiMetadata,
                 dataSources,
+                deleteQueryIndexInEveryRun,
                 owner
             )
         }


### PR DESCRIPTION
### Description
changes to support dynamic deletion of doc-level monitor query indices. manual backport #734 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
