### PR TITLE
add should_persist_and_alerts field to security-analytics

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/IndexExecutionContext.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/IndexExecutionContext.kt
@@ -21,7 +21,8 @@ data class IndexExecutionContext(
     val updatedIndexNames: List<String>,
     val concreteIndexNames: List<String>,
     val conflictingFields: List<String>,
-    val docIds: List<String>? = emptyList()
+    val docIds: List<String>? = emptyList(),
+    val findingIds: List<String>? = emptyList()
 ) : Writeable, ToXContent {
 
     @Throws(IOException::class)
@@ -34,7 +35,8 @@ data class IndexExecutionContext(
         updatedIndexNames = sin.readStringList(),
         concreteIndexNames = sin.readStringList(),
         conflictingFields = sin.readStringList(),
-        docIds = sin.readOptionalStringList()
+        docIds = sin.readOptionalStringList(),
+        findingIds = sin.readOptionalStringList()
     )
 
     override fun writeTo(out: StreamOutput?) {
@@ -47,6 +49,7 @@ data class IndexExecutionContext(
         out.writeStringCollection(concreteIndexNames)
         out.writeStringCollection(conflictingFields)
         out.writeOptionalStringCollection(docIds)
+        out.writeOptionalStringCollection(findingIds)
     }
 
     override fun toXContent(builder: XContentBuilder?, params: ToXContent.Params?): XContentBuilder {
@@ -60,6 +63,7 @@ data class IndexExecutionContext(
             .field("concrete_index_names", concreteIndexNames)
             .field("conflicting_fields", conflictingFields)
             .field("doc_ids", docIds)
+            .field("finding_ids", findingIds)
             .endObject()
         return builder
     }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -43,7 +43,7 @@ data class Monitor(
     val uiMetadata: Map<String, Any>,
     val dataSources: DataSources = DataSources(),
     val deleteQueryIndexInEveryRun: Boolean? = false,
-    val ignoreFindingsAndAlerts: Boolean? = false,
+    val shouldPersistFindingsAndAlerts: Boolean? = false,
     val owner: String? = "alerting"
 ) : ScheduledJob {
 
@@ -113,7 +113,7 @@ data class Monitor(
             DataSources()
         },
         deleteQueryIndexInEveryRun = sin.readOptionalBoolean(),
-        ignoreFindingsAndAlerts = sin.readOptionalBoolean(),
+        shouldPersistFindingsAndAlerts = sin.readOptionalBoolean(),
         owner = sin.readOptionalString()
     )
 
@@ -174,7 +174,7 @@ data class Monitor(
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
         builder.field(DATA_SOURCES_FIELD, dataSources)
         builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
-        builder.field(IGNORE_FINDINGS_AND_ALERTS_FIELD, ignoreFindingsAndAlerts)
+        builder.field(IGNORE_FINDINGS_AND_ALERTS_FIELD, shouldPersistFindingsAndAlerts)
         builder.field(OWNER_FIELD, owner)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -227,7 +227,7 @@ data class Monitor(
         out.writeBoolean(dataSources != null) // for backward compatibility with pre-existing monitors which don't have datasources field
         dataSources.writeTo(out)
         out.writeOptionalBoolean(deleteQueryIndexInEveryRun)
-        out.writeOptionalBoolean(ignoreFindingsAndAlerts)
+        out.writeOptionalBoolean(shouldPersistFindingsAndAlerts)
         out.writeOptionalString(owner)
     }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -43,6 +43,7 @@ data class Monitor(
     val uiMetadata: Map<String, Any>,
     val dataSources: DataSources = DataSources(),
     val deleteQueryIndexInEveryRun: Boolean? = false,
+    val ignoreFindingsAndAlerts: Boolean? = false,
     val owner: String? = "alerting"
 ) : ScheduledJob {
 
@@ -112,6 +113,7 @@ data class Monitor(
             DataSources()
         },
         deleteQueryIndexInEveryRun = sin.readOptionalBoolean(),
+        ignoreFindingsAndAlerts = sin.readOptionalBoolean(),
         owner = sin.readOptionalString()
     )
 
@@ -172,6 +174,7 @@ data class Monitor(
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
         builder.field(DATA_SOURCES_FIELD, dataSources)
         builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
+        builder.field(IGNORE_FINDINGS_AND_ALERTS_FIELD, ignoreFindingsAndAlerts)
         builder.field(OWNER_FIELD, owner)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -224,6 +227,7 @@ data class Monitor(
         out.writeBoolean(dataSources != null) // for backward compatibility with pre-existing monitors which don't have datasources field
         dataSources.writeTo(out)
         out.writeOptionalBoolean(deleteQueryIndexInEveryRun)
+        out.writeOptionalBoolean(ignoreFindingsAndAlerts)
         out.writeOptionalString(owner)
     }
 
@@ -245,6 +249,7 @@ data class Monitor(
         const val DATA_SOURCES_FIELD = "data_sources"
         const val ENABLED_TIME_FIELD = "enabled_time"
         const val DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD = "delete_query_index_in_every_run"
+        const val IGNORE_FINDINGS_AND_ALERTS_FIELD = "ignore_findings_and_alerts"
         const val OWNER_FIELD = "owner"
         val MONITOR_TYPE_PATTERN = Pattern.compile("[a-zA-Z0-9_]{5,25}")
 
@@ -274,6 +279,7 @@ data class Monitor(
             val inputs: MutableList<Input> = mutableListOf()
             var dataSources = DataSources()
             var deleteQueryIndexInEveryRun = false
+            var delegateMonitor = false
             var owner = "alerting"
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
@@ -332,6 +338,11 @@ data class Monitor(
                     } else {
                         xcp.booleanValue()
                     }
+                    IGNORE_FINDINGS_AND_ALERTS_FIELD -> delegateMonitor = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        delegateMonitor
+                    } else {
+                        xcp.booleanValue()
+                    }
                     OWNER_FIELD -> owner = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) owner else xcp.text()
                     else -> {
                         xcp.skipChildren()
@@ -360,6 +371,7 @@ data class Monitor(
                 uiMetadata,
                 dataSources,
                 deleteQueryIndexInEveryRun,
+                delegateMonitor,
                 owner
             )
         }

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -174,7 +174,7 @@ data class Monitor(
         if (uiMetadata.isNotEmpty()) builder.field(UI_METADATA_FIELD, uiMetadata)
         builder.field(DATA_SOURCES_FIELD, dataSources)
         builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
-        builder.field(IGNORE_FINDINGS_AND_ALERTS_FIELD, shouldPersistFindingsAndAlerts)
+        builder.field(SHOULD_PERSIST_FINDINGS_AND_ALERTS_FIELD, shouldPersistFindingsAndAlerts)
         builder.field(OWNER_FIELD, owner)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -249,7 +249,7 @@ data class Monitor(
         const val DATA_SOURCES_FIELD = "data_sources"
         const val ENABLED_TIME_FIELD = "enabled_time"
         const val DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD = "delete_query_index_in_every_run"
-        const val IGNORE_FINDINGS_AND_ALERTS_FIELD = "ignore_findings_and_alerts"
+        const val SHOULD_PERSIST_FINDINGS_AND_ALERTS_FIELD = "should_persist_findings_and_alerts"
         const val OWNER_FIELD = "owner"
         val MONITOR_TYPE_PATTERN = Pattern.compile("[a-zA-Z0-9_]{5,25}")
 
@@ -338,7 +338,7 @@ data class Monitor(
                     } else {
                         xcp.booleanValue()
                     }
-                    IGNORE_FINDINGS_AND_ALERTS_FIELD -> delegateMonitor = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                    SHOULD_PERSIST_FINDINGS_AND_ALERTS_FIELD -> delegateMonitor = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
                         delegateMonitor
                     } else {
                         xcp.booleanValue()

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/WorkflowRunContext.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/WorkflowRunContext.kt
@@ -17,7 +17,7 @@ data class WorkflowRunContext(
     val workflowId: String,
     val workflowMetadataId: String,
     val chainedMonitorId: String?,
-    val matchingDocIdsPerIndex: Map<String, List<String>>,
+    val matchingDocIdsPerIndex: Pair<Map<String, List<String>>, List<String>>,
     val auditDelegateMonitorAlerts: Boolean
 ) : Writeable, ToXContentObject {
     companion object {
@@ -30,7 +30,7 @@ data class WorkflowRunContext(
         sin.readString(),
         sin.readString(),
         sin.readOptionalString(),
-        sin.readMap() as Map<String, List<String>>,
+        Pair(sin.readMap() as Map<String, List<String>>, sin.readStringList()),
         sin.readBoolean()
     )
 
@@ -38,7 +38,8 @@ data class WorkflowRunContext(
         out.writeString(workflowId)
         out.writeString(workflowMetadataId)
         out.writeOptionalString(chainedMonitorId)
-        out.writeMap(matchingDocIdsPerIndex)
+        out.writeMap(matchingDocIdsPerIndex.first)
+        out.writeStringCollection(matchingDocIdsPerIndex.second)
         out.writeBoolean(auditDelegateMonitorAlerts)
     }
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/action/DocLevelMonitorFanOutRequestTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/action/DocLevelMonitorFanOutRequestTests.kt
@@ -65,7 +65,7 @@ class DocLevelMonitorFanOutRequestTests {
             Workflow.NO_ID,
             Workflow.NO_ID,
             Monitor.NO_ID,
-            mutableMapOf("index" to listOf("1")),
+            Pair(mutableMapOf("index" to listOf("1")), listOf("finding1")),
             true
         )
         val docLevelMonitorFanOutRequest = DocLevelMonitorFanOutRequest(


### PR DESCRIPTION
### Description
add `should_persist_and_alerts` field to security-analytics
continuing from pr #756 

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
