### PR TITLE
Monitor model changed to add an optional fanoutEnabled field

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
@@ -23,7 +23,7 @@ data class DocLevelMonitorInput(
         sin.readString(), // description
         sin.readStringList(), // indices
         sin.readList(::DocLevelQuery), // docLevelQueries
-        sin.readOptionalBoolean(), // fanoutEnabled
+        sin.readOptionalBoolean() // fanoutEnabled
     )
 
     override fun asTemplateArg(): Map<String, Any> {

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/DocLevelMonitorInput.kt
@@ -14,14 +14,16 @@ import java.io.IOException
 data class DocLevelMonitorInput(
     val description: String = NO_DESCRIPTION,
     val indices: List<String>,
-    val queries: List<DocLevelQuery>
+    val queries: List<DocLevelQuery>,
+    val fanoutEnabled: Boolean? = true
 ) : Input {
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         sin.readString(), // description
         sin.readStringList(), // indices
-        sin.readList(::DocLevelQuery) // docLevelQueries
+        sin.readList(::DocLevelQuery), // docLevelQueries
+        sin.readOptionalBoolean(), // fanoutEnabled
     )
 
     override fun asTemplateArg(): Map<String, Any> {
@@ -41,6 +43,7 @@ data class DocLevelMonitorInput(
         out.writeString(description)
         out.writeStringCollection(indices)
         out.writeCollection(queries)
+        out.writeOptionalBoolean(fanoutEnabled)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -49,6 +52,7 @@ data class DocLevelMonitorInput(
             .field(DESCRIPTION_FIELD, description)
             .field(INDICES_FIELD, indices.toTypedArray())
             .field(QUERIES_FIELD, queries.toTypedArray())
+            .field(FANOUT_FIELD, fanoutEnabled)
             .endObject()
             .endObject()
         return builder
@@ -59,7 +63,7 @@ data class DocLevelMonitorInput(
         const val INDICES_FIELD = "indices"
         const val DOC_LEVEL_INPUT_FIELD = "doc_level_input"
         const val QUERIES_FIELD = "queries"
-
+        const val FANOUT_FIELD = "fan_out_enabled"
         const val NO_DESCRIPTION = ""
 
         val XCONTENT_REGISTRY = NamedXContentRegistry.Entry(
@@ -74,6 +78,7 @@ data class DocLevelMonitorInput(
             var description: String = NO_DESCRIPTION
             val indices: MutableList<String> = mutableListOf()
             val docLevelQueries: MutableList<DocLevelQuery> = mutableListOf()
+            var fanoutEnabled: Boolean? = true
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -102,10 +107,15 @@ data class DocLevelMonitorInput(
                             docLevelQueries.add(DocLevelQuery.parse(xcp))
                         }
                     }
+                    FANOUT_FIELD -> fanoutEnabled = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
+                        fanoutEnabled
+                    } else {
+                        xcp.booleanValue()
+                    }
                 }
             }
 
-            return DocLevelMonitorInput(description = description, indices = indices, queries = docLevelQueries)
+            return DocLevelMonitorInput(description = description, indices = indices, queries = docLevelQueries, fanoutEnabled = fanoutEnabled)
         }
 
         @JvmStatic

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -44,7 +44,7 @@ data class Monitor(
     val dataSources: DataSources = DataSources(),
     val deleteQueryIndexInEveryRun: Boolean? = false,
     val shouldCreateSingleAlertForFindings: Boolean? = false,
-    val owner: String? = "alerting",
+    val owner: String? = "alerting"
 ) : ScheduledJob {
 
     override val type = MONITOR_TYPE
@@ -372,7 +372,7 @@ data class Monitor(
                 dataSources,
                 deleteQueryIndexInEveryRun,
                 delegateMonitor,
-                owner,
+                owner
             )
         }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -45,7 +45,7 @@ data class Monitor(
     val deleteQueryIndexInEveryRun: Boolean? = false,
     val shouldCreateSingleAlertForFindings: Boolean? = false,
     val owner: String? = "alerting",
-    val fanoutEnabled: Boolean? = true,
+    val fanoutEnabled: Boolean? = true
 ) : ScheduledJob {
 
     override val type = MONITOR_TYPE

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -45,7 +45,6 @@ data class Monitor(
     val deleteQueryIndexInEveryRun: Boolean? = false,
     val shouldCreateSingleAlertForFindings: Boolean? = false,
     val owner: String? = "alerting",
-    val fanoutEnabled: Boolean? = true
 ) : ScheduledJob {
 
     override val type = MONITOR_TYPE
@@ -115,7 +114,6 @@ data class Monitor(
         },
         deleteQueryIndexInEveryRun = sin.readOptionalBoolean(),
         shouldCreateSingleAlertForFindings = sin.readOptionalBoolean(),
-        fanoutEnabled = sin.readOptionalBoolean(),
         owner = sin.readOptionalString()
     )
 
@@ -177,7 +175,6 @@ data class Monitor(
         builder.field(DATA_SOURCES_FIELD, dataSources)
         builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
         builder.field(SHOULD_CREATE_SINGLE_ALERT_FOR_FINDINGS_FIELD, shouldCreateSingleAlertForFindings)
-        builder.field(FAN_OUT_ENABLED_FIELD, fanoutEnabled)
         builder.field(OWNER_FIELD, owner)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
@@ -231,7 +228,6 @@ data class Monitor(
         dataSources.writeTo(out)
         out.writeOptionalBoolean(deleteQueryIndexInEveryRun)
         out.writeOptionalBoolean(shouldCreateSingleAlertForFindings)
-        out.writeOptionalBoolean(fanoutEnabled)
         out.writeOptionalString(owner)
     }
 
@@ -254,7 +250,6 @@ data class Monitor(
         const val ENABLED_TIME_FIELD = "enabled_time"
         const val DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD = "delete_query_index_in_every_run"
         const val SHOULD_CREATE_SINGLE_ALERT_FOR_FINDINGS_FIELD = "should_create_single_alert_for_findings"
-        const val FAN_OUT_ENABLED_FIELD = "fan_out_enabled"
         const val OWNER_FIELD = "owner"
         val MONITOR_TYPE_PATTERN = Pattern.compile("[a-zA-Z0-9_]{5,25}")
 
@@ -286,7 +281,6 @@ data class Monitor(
             var deleteQueryIndexInEveryRun = false
             var delegateMonitor = false
             var owner = "alerting"
-            var fanoutEnabled = true
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -349,11 +343,6 @@ data class Monitor(
                     } else {
                         xcp.booleanValue()
                     }
-                    FAN_OUT_ENABLED_FIELD -> fanoutEnabled = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) {
-                        fanoutEnabled
-                    } else {
-                        xcp.booleanValue()
-                    }
                     OWNER_FIELD -> owner = if (xcp.currentToken() == XContentParser.Token.VALUE_NULL) owner else xcp.text()
                     else -> {
                         xcp.skipChildren()
@@ -384,7 +373,6 @@ data class Monitor(
                 deleteQueryIndexInEveryRun,
                 delegateMonitor,
                 owner,
-                fanoutEnabled
             )
         }
 


### PR DESCRIPTION
### Description
Detectors configured with aggregation sigma rules should ideally generate only one alert in one execution when a set of documents match the rule’s condition. But currently there are duplicate alerts being generated when aggregate sigma rules are matched.
This PR adds a field in monitor  `fanoutEnabled` (optional field), default value of this flag will be true. When detector is created/updated, the value of this field will be set to false in case chained findings doc level monitor, this will ensure that fanout approach will be disabled when executing doc level monitor

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
