### PR TITLE
Fix 2.x branch github CI workflow. (#777)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - "*"
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:
@@ -30,16 +28,20 @@ jobs:
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
 
       - name: Setup Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Build and Test
         run: |
@@ -65,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v1


### PR DESCRIPTION
* Bumped action/checkout version. (#774)

* add should_create_single_alert_for_findings field to security-analytics (#757)





* Monitor model changed to add an optional fanoutEnabled field (#758)

* Monitor model changed to add an optional fanoutEnabled field



* Monitor model changed to add an optional fanoutEnabled field



* move fanoutEnabled to docLevel input



* move fanoutEnabled to docLevel input



* move fanoutEnabled to docLevel input



---------




* Bumped action/checkout version.



---------






* Bumped action/checkout version.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



* Fix CI build.



---------

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
