### PR TITLE
[2.x] Updating ReplicationPluginInterface from open class to object

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/replication/ReplicationPluginInterface.kt
+++ b/src/main/kotlin/org/opensearch/commons/replication/ReplicationPluginInterface.kt
@@ -17,8 +17,7 @@ import org.opensearch.core.common.io.stream.Writeable
 /**
  * Transport action plugin interfaces for the cross-cluster-replication plugin.
  */
-open class ReplicationPluginInterface {
-
+object ReplicationPluginInterface {
     /**
      * Stop replication.
      * @param client Node client for making transport action
@@ -26,7 +25,7 @@ open class ReplicationPluginInterface {
      * @param listener The listener for getting response
      */
 
-    open fun stopReplication(
+    fun stopReplication(
         client: Client,
         request: StopIndexReplicationRequest,
         listener: ActionListener<AcknowledgedResponse>

--- a/src/test/kotlin/org/opensearch/commons/replication/ReplicationPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/replication/ReplicationPluginInterfaceTests.kt
@@ -36,9 +36,8 @@ internal class ReplicationPluginInterfaceTests {
                 actionListener.onResponse(acknowledgedResponse) // Simulate success
             }
 
-        val replicationPluginInterface = ReplicationPluginInterface()
         // Call method under test
-        replicationPluginInterface.stopReplication(client, request, listener)
+        ReplicationPluginInterface.stopReplication(client, request, listener)
         // Verify that listener.onResponse is called with the correct response
         verify(listener).onResponse(acknowledgedResponse)
     }
@@ -58,9 +57,8 @@ internal class ReplicationPluginInterfaceTests {
                 actionListener.onFailure(exception) // Simulate failure
             }
 
-        val replicationPluginInterface = ReplicationPluginInterface()
         // Call method under test
-        replicationPluginInterface.stopReplication(client, request, listener)
+        ReplicationPluginInterface.stopReplication(client, request, listener)
         // Verify that listener.onResponse is called with the correct response
         verify(listener).onFailure(exception)
     }


### PR DESCRIPTION

### Description
As per the review comment received on [PR](https://github.com/opensearch-project/common-utils/pull/667#discussion_r1966444486) on main branch, the suggestion was to convert ReplicationPluginInterface to an object and have static methods, instead of an open class and open methods.
The change works and is validated.

On 2.x branch, the [PR](https://github.com/opensearch-project/common-utils/pull/789) was already merged with open class, this new PR is to only fix this gap on the 2.x branch.


### Related Issues
[Unfollow action](https://github.com/opensearch-project/index-management/issues/726)

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
