### PR TITLE
Change 3.0.0 qualifier from alpha1 to beta1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
         kotlin_version = System.getProperty("kotlin.version", "1.9.25")
     }
 


### PR DESCRIPTION
### Description

Change 3.0.0 qualifier from alpha1 to beta1

The core repo has already been changed to beta1: https://github.com/opensearch-project/OpenSearch/pull/17621

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
