### PR TITLE
Added Basic API's for Storage Repository

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/storage/api/StorageAdapterFactory.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/api/StorageAdapterFactory.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.api
+
+/**
+ * StorageAdapterFactory is used by the StorageService to get the StorageRepository
+ * based on the provided StorageEngine.
+ */
+interface StorageAdapterFactory {
+    /**
+     * returns the StorageRepository based on the provided StorageEngine.
+     *
+     * @param engine The StorageEngine.
+     * @return The StorageRepository
+     */
+    fun getAdapter(engine: StorageEngine): StorageRepository
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/api/StorageEngine.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/api/StorageEngine.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.api
+
+enum class StorageEngine {
+    OPEN_SEARCH_CLUSTER,
+    DYNAMO_DB
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/api/StorageOperation.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/api/StorageOperation.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.api
+
+enum class StorageOperation {
+    SAVE,
+    DELETE,
+    GET,
+    UPDATE,
+    SEARCH
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/api/StorageRepository.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/api/StorageRepository.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.api
+
+import org.opensearch.commons.storage.model.StorageRequest
+import org.opensearch.commons.storage.model.StorageResponse
+
+/**
+ * The StorageRepository Interface defines the basic operations such as saving,
+ *  retrieving, searching, updating, and deleting data for the storage accessor.
+ */
+interface StorageRepository {
+    suspend fun save(request: StorageRequest<Any>): StorageResponse<Any>
+    suspend fun get(request: StorageRequest<Any>): StorageResponse<Any>
+    suspend fun search(request: StorageRequest<Any>): StorageResponse<Any>
+    suspend fun update(request: StorageRequest<Any>): StorageResponse<Any>
+    suspend fun delete(request: StorageRequest<Any>): StorageResponse<Any>
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/core/StorageService.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/core/StorageService.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.core
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.commons.storage.api.StorageAdapterFactory
+import org.opensearch.commons.storage.api.StorageOperation
+import org.opensearch.commons.storage.model.StorageRequest
+import org.opensearch.commons.storage.model.StorageResponse
+
+/**
+ * StorageService is the primary layer for handling requests from the clients and
+ * delegates the requests to the appropriate storage adapter and returns the response.
+ */
+class StorageService(private val storageAdapterFactory: StorageAdapterFactory) {
+    private val log = LogManager.getLogger(StorageService::class.java)
+
+    suspend fun handleRequest(request: StorageRequest<Any>): StorageResponse<Any> {
+        log.info(
+            "[StorageService] Handling request: engine=${request.engine}, operation=${request.operation}"
+        )
+
+        val storageRepository = storageAdapterFactory.getAdapter(request.engine)
+        return when (request.operation) {
+            StorageOperation.SAVE -> storageRepository.save(request)
+            StorageOperation.GET -> storageRepository.get(request)
+            StorageOperation.SEARCH -> storageRepository.search(request)
+            StorageOperation.UPDATE -> storageRepository.update(request)
+            StorageOperation.DELETE -> storageRepository.delete(request)
+        }
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/error/StorageError.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/error/StorageError.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.error
+
+/**
+ * Represents a storage-related error that can be returned as part of a [StorageResponse].
+ */
+sealed class StorageError {
+    data class Generic(val message: String, val cause: Throwable? = null) : StorageError()
+}

--- a/src/main/kotlin/org/opensearch/commons/storage/model/StorageRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/model/StorageRequest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.model
+
+import org.opensearch.commons.storage.api.StorageEngine
+import org.opensearch.commons.storage.api.StorageOperation
+
+/**
+ * StorageRequest represents a request to the storage service.
+ * @param <T> The type of the payload.
+ */
+data class StorageRequest<T> (
+    val payload: T? = null,
+    val options: Any? = null,
+    val operation: StorageOperation,
+    val engine: StorageEngine
+)

--- a/src/main/kotlin/org/opensearch/commons/storage/model/StorageResponse.kt
+++ b/src/main/kotlin/org/opensearch/commons/storage/model/StorageResponse.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.storage.model
+
+import org.opensearch.commons.storage.api.StorageEngine
+import org.opensearch.commons.storage.api.StorageOperation
+import org.opensearch.commons.storage.error.StorageError
+
+/**
+ * StorageResponse represents the response returned after handling a StorageRequest
+ * @param <T> The type of the payload.
+ */
+data class StorageResponse<T> (
+    val payload: T? = null,
+    val operation: StorageOperation,
+    val engine: StorageEngine,
+    val error: StorageError? = null
+)


### PR DESCRIPTION
### Description
- Added a generic storage access repository which abstracts the underlying storage layer to perform CRUD operations.
- Added a storage service which handles storage requests from client and passes it onto the appropriate storage repository.
- Added storage request, storage response, operations and error types.

### Related Issues

### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`.
- [X] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
