### PR TITLE
Update user parsing to include custom attribute names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,12 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "org.mockito:mockito-core:3.10.0"
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.10.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "com.cronutils:cron-utils:9.1.6"
     testImplementation "commons-validator:commons-validator:1.7"
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
 
     ktlint "com.pinterest:ktlint:0.47.1"
 }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -178,6 +178,7 @@ final public class User implements Writeable, ToXContent {
         List<String> backendRoles = new ArrayList<>();
         List<String> roles = new ArrayList<>();
         String requestedTenant = null;
+        List<String> customAttNames = new ArrayList<>();
 
         if ((strs.length > 1) && !Strings.isNullOrEmpty(strs[1])) {
             backendRoles.addAll(Arrays.stream(strs[1].split(",")).map(Utils::unescapePipe).toList());
@@ -188,7 +189,10 @@ final public class User implements Writeable, ToXContent {
         if ((strs.length > 3) && !Strings.isNullOrEmpty(strs[3])) {
             requestedTenant = unescapePipe(strs[3].trim());
         }
-        return new User(userName, backendRoles, roles, Arrays.asList(), requestedTenant);
+        if ((strs.length > 4) && !Strings.isNullOrEmpty(strs[4])) {
+            customAttNames.addAll(Arrays.stream(strs[4].split(",")).map(Utils::unescapePipe).toList());
+        }
+        return new User(userName, backendRoles, roles, customAttNames, requestedTenant);
     }
 
     @Override

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -114,7 +114,8 @@ public class UserTest {
     @Test
     public void testParseUserString() {
         ThreadContext tc = new ThreadContext(Settings.EMPTY);
-        tc.putTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT, "myuser|bckrole1,bckrol2|role1,role2|myTenant");
+       tc.putTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT,
+                "myuser|bckrole1,bckrol2|role1,role2|myTenant|attr.proxy.prop1,attr.internal.prop2");
         String str = tc.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
         User user = User.parse(str);
 
@@ -124,6 +125,8 @@ public class UserTest {
         assertTrue(user.getRoles().contains("role1"));
         assertTrue(user.getRoles().contains("role2"));
         assertEquals("myTenant", user.getRequestedTenant());
+        assertTrue(user.getCustomAttNames().contains("attr.proxy.prop1"));
+        assertTrue(user.getCustomAttNames().contains("attr.internal.prop2"));
     }
 
     @Test


### PR DESCRIPTION
### Description

As part of https://github.com/opensearch-project/alerting/issues/1829, I found that the user parsing in this library, which is used by the alerting plugin, does not parse custom attribute names from a user string. 

The current implementation makes sense because the security plugin does not currently include custom attribute names in the user string in the thread context: https://github.com/opensearch-project/security/blob/dfe16b004a6bb1c8d2bc50ac0c0f76780a3519cb/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java#L276-L290. 

However, I plan to update the security plugin to include custom attribute names in the thread context. Ultimately, the goal of this change and other related changes is to make sure that user custom attributes are available when the alerting plugin executes monitor queries, so that DLS parameter substitution will work correctly.

### Related Issues

Related to https://github.com/opensearch-project/alerting/issues/1829

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
