### PR TITLE
Add Mattermost as ConfigType for notifications channel

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/model/ConfigType.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/ConfigType.kt
@@ -59,6 +59,11 @@ enum class ConfigType(val tag: String) {
         override fun toString(): String {
             return tag
         }
+    },
+    MATTERMOST("mattermost") {
+        override fun toString(): String {
+            return tag
+        }
     };
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/config/ConfigDataProperties.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/config/ConfigDataProperties.kt
@@ -38,7 +38,8 @@ internal object ConfigDataProperties {
         Pair(ConfigType.SES_ACCOUNT, ConfigProperty(SesAccount.reader, SesAccount.xParser)),
         Pair(ConfigType.EMAIL_GROUP, ConfigProperty(EmailGroup.reader, EmailGroup.xParser)),
         Pair(ConfigType.SMTP_ACCOUNT, ConfigProperty(SmtpAccount.reader, SmtpAccount.xParser)),
-        Pair(ConfigType.MICROSOFT_TEAMS, ConfigProperty(MicrosoftTeams.reader, MicrosoftTeams.xParser))
+        Pair(ConfigType.MICROSOFT_TEAMS, ConfigProperty(MicrosoftTeams.reader, MicrosoftTeams.xParser)),
+        Pair(ConfigType.MATTERMOST, ConfigProperty(Slack.reader, Slack.xParser))
     )
 
     /**
@@ -65,6 +66,7 @@ internal object ConfigDataProperties {
             ConfigType.SNS -> configData is Sns
             ConfigType.SES_ACCOUNT -> configData is SesAccount
             ConfigType.MICROSOFT_TEAMS -> configData is MicrosoftTeams
+            ConfigType.MATTERMOST -> configData is Slack
             ConfigType.NONE -> true
         }
     }


### PR DESCRIPTION
### Description

This PR adds a new ConfigType called `Mattermost` to the notifications ConfigType enum. Mattermost accepts the same payload format as Slack, but different URL naming. Since OpenSearch 3.0.0, users are saying they can no longer use the "Slack" notification channel type for other slack-like communication platforms like mattermost because of the URL validation logic. This PR seeks to establish a separate channel type for those other communication platforms like Discord, RocketChat, Zulip and Mattermost

### Related Issues

Part of https://github.com/opensearch-project/notifications/issues/1048

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
