### PR TITLE
Adding null safe time field builder for XContentBuilder

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/IndexUtils.kt
@@ -66,6 +66,10 @@ fun XContentBuilder.optionalUsernameField(name: String, user: User?): XContentBu
     return this.field(name, user.name)
 }
 
+fun XContentBuilder.nonOptionalTimeField(name: String, instant: Instant): XContentBuilder {
+    return this.timeField(name, "${name}_in_millis", instant.toEpochMilli())
+}
+
 fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContentBuilder {
     if (instant == null) {
         return nullField(name)


### PR DESCRIPTION
### Description
Adding null safe time field builder for XContentBuilder, which is used in PPL Alerting

### Related Issues
N/A

### Check List
- [N] New functionality includes testing.
- [N/A] New functionality has been documented.
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [Y] Commits are signed per the DCO using `--signoff`.
- [N/A] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
