### PR TITLE
Update user attributes XContent parsing logic

### DIFF
--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -284,6 +284,7 @@ final public class User implements Writeable, ToXContent {
 
         if (customAttributes.size() > 0) {
             builder.field(CUSTOM_ATTRIBUTES_FIELD, customAttributes);
+            builder.field(CUSTOM_ATTRIBUTE_NAMES_FIELD, this.getCustomAttributeNamesFromMap(customAttributes));
         } else {
             builder.field(CUSTOM_ATTRIBUTE_NAMES_FIELD, new ArrayList<>());
         }
@@ -379,7 +380,10 @@ final public class User implements Writeable, ToXContent {
     }
 
     private List<String> getCustomAttributeNamesFromMap(Map<String, String> customAttributes) {
-        List<String> customAttNames = new ArrayList<>(this.customAttributes.keySet());
+        List<String> customAttNames = new ArrayList<>();
+        for (Map.Entry<String, String> entry : this.customAttributes.entrySet()) {
+            customAttNames.add(entry.getKey() + "=" + entry.getValue());
+        }
         return customAttNames;
     }
 }

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -211,7 +211,9 @@ final public class User implements Writeable, ToXContent {
                 case CUSTOM_ATTRIBUTE_NAMES_FIELD:
                     ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
-                        customAttributes.put(parser.text(), null);
+                        // Assume custom attribute name values are key=value with no extra "="
+                        String[] attrInfo = parser.text().split("=");
+                        customAttributes.put(attrInfo[0], attrInfo[1]);
                     }
                     break;
                 case REQUESTED_TENANT_FIELD:

--- a/src/main/java/org/opensearch/commons/authuser/User.java
+++ b/src/main/java/org/opensearch/commons/authuser/User.java
@@ -285,7 +285,6 @@ final public class User implements Writeable, ToXContent {
             .field(REQUESTED_TENANT_ACCESS, requestedTenantAccess);
 
         if (customAttributes.size() > 0) {
-            builder.field(CUSTOM_ATTRIBUTES_FIELD, customAttributes);
             builder.field(CUSTOM_ATTRIBUTE_NAMES_FIELD, this.getCustomAttributeNamesFromMap(customAttributes));
         } else {
             builder.field(CUSTOM_ATTRIBUTE_NAMES_FIELD, new ArrayList<>());

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -543,9 +543,6 @@ public class UserTest {
                 "roles": ["ops_data"],
                 "user_requested_tenant": null,
                 "user_requested_tenant_access": null,
-                "custom_attributes": {
-                    "attr1": "value1"
-                },
                 "custom_attribute_names": [
                     "attr1=value1"
                 ]

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -543,7 +543,10 @@ public class UserTest {
                 "user_requested_tenant_access": null,
                 "custom_attributes": {
                     "attr1": "value1"
-                }
+                },
+                "custom_attribute_names": [
+                    "attr1=value1"
+                ]
             }
             """;
         assertEquals(expectedUserJson.replace("\n", "").replace("\s", ""), xcontent.toString().replace("\n", ""));

--- a/src/test/java/org/opensearch/commons/authuser/UserTest.java
+++ b/src/test/java/org/opensearch/commons/authuser/UserTest.java
@@ -13,6 +13,7 @@ import static org.opensearch.commons.ConfigConstants.OPENSEARCH_SECURITY_USER_IN
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -474,6 +475,7 @@ public class UserTest {
         assertEquals(1, user.getCustomAttributes().size());
         assertTrue(user.getCustomAttributes().containsKey("attr1"));
         assertTrue(user.getCustomAttributes().containsValue("val1"));
+        assertEquals(user.getCustomAttNames(), Arrays.asList("attr1=val1"));
     }
 
     @Test


### PR DESCRIPTION
### Description

A previous PR, #827, introduced a change to write user custom attributes to a `custom_attributes` when serializing a `User` to XContent.

However, this change has an adverse affect on many downstream plugins which do not expect a `custom_attributes` property for a user in their mappings: https://github.com/search?q=org%3Aopensearch-project+custom_attribute_names+language%3AJSON&type=code&l=JSON

To avoid breaking changes for downstream plugins while still representing the custom attributes in the XContent, this PR writes custom attributes to the `custom_attribute_names` property of XContent in the form of `key=value`. While it is admittedly confusing to have a property named `custom_attribute_names` that actually contains both custom attribute names and values, it is a worthwhile approach to avoid the breaking changes on downstream plugins. 

### Related Issues

Related to https://github.com/opensearch-project/alerting/issues/1829

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
