### PR TITLE
Fix validation message in ClusterMetricsInput

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -33,7 +33,7 @@ data class ClusterMetricsInput(
     // Verify parameters are valid during creation
     init {
         require(validateFields()) {
-            "The uri.api_type field, uri.path field, or uri.uri field must be defined."
+            "The uri.path field, or uri.url field must be defined."
         }
 
         // Create an UrlValidator that only accepts "http" and "https" as valid scheme and allows local URLs.

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
@@ -159,7 +159,7 @@ class ClusterMetricsInputTests {
         url = ""
 
         // WHEN + THEN
-        assertFailsWith<IllegalArgumentException>("The uri.api_type field, uri.path field, or uri.uri field must be defined.") {
+        assertFailsWith<IllegalArgumentException>("The uri.path field, or uri.url field must be defined.") {
             ClusterMetricsInput(path, pathParams, url)
         }
     }
@@ -172,7 +172,7 @@ class ClusterMetricsInputTests {
         url = ""
 
         // WHEN + THEN
-        assertFailsWith<IllegalArgumentException>("The uri.api_type field, uri.path field, or uri.uri field must be defined.") {
+        assertFailsWith<IllegalArgumentException>("The uri.path field, or uri.url field must be defined.") {
             ClusterMetricsInput(path, pathParams, url)
         }
     }


### PR DESCRIPTION
### Description

Fix validation error message typos in ClusterMetricsInput.
1. Remove the unused uri.api_type field (it is made automatically by path or url).
(ref: https://github.com/opensearch-project/common-utils/blob/main/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt#L122-L149)

2. Rename uri.uri to uri.url.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
