### PR TITLE
Bump logback from 1.5.19 to 1.5.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,8 +76,8 @@ configurations {
     }
     ktlint {
       resolutionStrategy {
-          force "ch.qos.logback:logback-classic:1.5.19"
-          force "ch.qos.logback:logback-core:1.5.19"
+          force "ch.qos.logback:logback-classic:1.5.32"
+          force "ch.qos.logback:logback-core:1.5.32"
       }
    }
 }


### PR DESCRIPTION
### Description

Bump logback from 1.5.19 to 1.5.32

### Related Issues

Resolves whitesource check failures: https://github.com/opensearch-project/common-utils/pull/906/checks?check_run_id=65021866146

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
