### PR TITLE
Validate api_type matches path in ClusterMetricsInput

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -123,6 +123,7 @@ data class ClusterMetricsInput(
             var path = ""
             var pathParams = ""
             var url = ""
+            var apiType = ""
             val clusters = mutableListOf<String>()
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
@@ -131,6 +132,7 @@ data class ClusterMetricsInput(
                 val fieldName = xcp.currentName()
                 xcp.nextToken()
                 when (fieldName) {
+                    API_TYPE_FIELD -> apiType = xcp.text()
                     PATH_FIELD -> path = xcp.text()
                     PATH_PARAMS_FIELD -> pathParams = xcp.text()
                     URL_FIELD -> url = xcp.text()
@@ -144,6 +146,17 @@ data class ClusterMetricsInput(
                     }
                 }
             }
+
+            if (apiType.isNotEmpty() && path.isNotEmpty()) {
+                val derivedType = ClusterMetricType.values()
+                    .filter { it != ClusterMetricType.BLANK }
+                    .find { path.startsWith(it.prependPath) || path.startsWith(it.defaultPath) }
+
+                require(derivedType != null && derivedType.name == apiType) {
+                    "The provided api_type [$apiType] does not match the path [$path]."
+                }
+            }
+
             return ClusterMetricsInput(path, pathParams, url, clusters)
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
@@ -591,4 +591,43 @@ class ClusterMetricsInputTests {
             )
         }
     }
+
+    @Test
+    fun `test parseInner rejects mismatched api_type and path`() {
+        val inputJson = """
+            {"uri":{"api_type":"CLUSTER_STATS","path":"/_cat/indices","path_params":"","url":"","clusters":[]}}
+        """.trimIndent()
+        val xcp = org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                inputJson
+            )
+        xcp.nextToken() // START_OBJECT (root)
+        xcp.nextToken() // FIELD_NAME "uri"
+        xcp.nextToken() // START_OBJECT (uri)
+
+        assertFailsWith<IllegalArgumentException>("The provided api_type") {
+            ClusterMetricsInput.parseInner(xcp)
+        }
+    }
+
+    @Test
+    fun `test parseInner accepts matching api_type and path`() {
+        val inputJson = """
+            {"uri":{"api_type":"CAT_INDICES","path":"/_cat/indices","path_params":"","url":"","clusters":[]}}
+        """.trimIndent()
+        val xcp = org.opensearch.common.xcontent.json.JsonXContent.jsonXContent
+            .createParser(
+                org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY,
+                org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                inputJson
+            )
+        xcp.nextToken()
+        xcp.nextToken()
+        xcp.nextToken()
+
+        val input = ClusterMetricsInput.parseInner(xcp)
+        assertEquals(ClusterMetricsInput.ClusterMetricType.CAT_INDICES, input.clusterMetricType)
+    }
 }


### PR DESCRIPTION
### Description                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                              
When creating a cluster metrics monitor, the `api_type` field was never parsed in `ClusterMetricsInput.parseInner()` — the user-provided value is ignored entirely. The `clusterMetricType` is always derived from the `path` via `findApiType(constructedUri.
path)` in the `init` block. This allowed creating monitors with mismatched `api_type` and `path` fields (e.g., user sends `api_type: CLUSTER_STATS` with `path: /_cat/indices`, but `CAT_INDICES` is derived from the path). These malformed monitors could no
t be deleted via the DeleteMonitor API, failing with "The provided URL and URI fields form different URLs."                                                                                                                                                   
                                                                                                                                                                                                                                                              
Added validation in `parseInner` to parse the `api_type` field and reject requests where the provided `api_type` does not match the type derived from the `path`.                                                                                             
                                                                                                                                                                                                                                                              
### Testing                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
**Before fix** — monitor created successfully. User-provided `api_type` is ignored, type is derived from `path` instead:                                                                                                                                      
json  
```                                                                                                                                                                                                                                                        
POST plugins/alerting/monitors                                                                                                                                                                                                                                
// api_type: CLUSTER_STATS, path: /_cat/indices/*?format=json&bytes=b                                                                                                                                                                                         
                                                                                                                                                                                                                                                              
Response: 200 OK — api_type stored as CAT_INDICES (derived from path, user input ignored)                                                                                                                                                                     
                                                                                                                                                                                                                                                              
// Attempting to delete fails:                                                                                                                                                                                                                                
DELETE plugins/alerting/monitors/<monitor_id>                                                                                                                                                                                                                 
{ "error": { "reason": "The provided URL and URI fields form different URLs." }, "status": 400 }                                                                                                                                                              
```
                                                                                                                                                                                                                                                              
**After fix** — monitor creation rejected with clear error:                                                                                                                                                                                                   
json                                                                                                                                                                                                                                                          

```
POST plugins/alerting/monitors                                                                                                                                                                                                                                
// Same request                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                              
Response: 400 Bad Request                                                                                                                                                                                                                                     
{ "error": { "reason": "The provided api_type [CLUSTER_STATS] does not match the path [/_cat/indices/*?format=json&bytes=b]." }, "status": 400 }                                                                                                              
 ```                                  

### Related Issues
Resolves opensearch-project/alerting#1987

### Check List
- [X ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [X ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
