### PR TITLE
Remove hardcoded trigger limit from Monitor data class and make number of triggers per monitor configurable

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -4,7 +4,6 @@ import org.opensearch.Version
 import org.opensearch.common.CheckedFunction
 import org.opensearch.commons.alerting.model.remote.monitors.RemoteMonitorTrigger
 import org.opensearch.commons.alerting.util.IndexUtils.Companion.MONITOR_MAX_INPUTS
-import org.opensearch.commons.alerting.util.IndexUtils.Companion.MONITOR_MAX_TRIGGERS
 import org.opensearch.commons.alerting.util.IndexUtils.Companion.NO_SCHEMA_VERSION
 import org.opensearch.commons.alerting.util.IndexUtils.Companion._ID
 import org.opensearch.commons.alerting.util.IndexUtils.Companion._VERSION
@@ -76,7 +75,6 @@ data class Monitor(
             require(enabledTime == null)
         }
         require(inputs.size <= MONITOR_MAX_INPUTS) { "Monitors can only have $MONITOR_MAX_INPUTS search input." }
-        require(triggers.size <= MONITOR_MAX_TRIGGERS) { "Monitors can only support up to $MONITOR_MAX_TRIGGERS triggers." }
         if (this.isBucketLevelMonitor()) {
             inputs.forEach { input ->
                 require(input is SearchInput) { "Unsupported input [$input] for Monitor" }

--- a/src/main/kotlin/org/opensearch/commons/alerting/util/IndexUtils.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/IndexUtils.kt
@@ -36,8 +36,6 @@ class IndexUtils {
         const val MONITOR_MAX_INPUTS = 1
         const val WORKFLOW_MAX_INPUTS = 1
 
-        const val MONITOR_MAX_TRIGGERS = 10
-
         const val _ID = "_id"
         const val _VERSION = "_version"
 

--- a/src/test/kotlin/org/opensearch/commons/alerting/MonitorTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/MonitorTests.kt
@@ -3,8 +3,8 @@ package org.opensearch.commons.alerting
 import org.junit.jupiter.api.Test
 import org.opensearch.commons.alerting.model.Trigger
 import org.opensearch.test.OpenSearchTestCase
-import java.lang.IllegalArgumentException
 import java.time.Instant
+import kotlin.test.assertEquals
 
 internal class MonitorTests {
     @Test
@@ -27,20 +27,17 @@ internal class MonitorTests {
     }
 
     @Test
-    fun `test max triggers`() {
+    fun `test monitor allows more than 10 triggers`() {
         val monitor = randomQueryLevelMonitor()
 
-        val tooManyTriggers = mutableListOf<Trigger>()
+        val manyTriggers = mutableListOf<Trigger>()
         var i = 0
         while (i <= 10) {
-            tooManyTriggers.add(randomQueryLevelTrigger())
+            manyTriggers.add(randomQueryLevelTrigger())
             ++i
         }
 
-        try {
-            monitor.copy(triggers = tooManyTriggers)
-            OpenSearchTestCase.fail("Monitor with too many triggers should be rejected.")
-        } catch (e: IllegalArgumentException) {
-        }
+        val monitorWithManyTriggers = monitor.copy(triggers = manyTriggers)
+        assertEquals(11, monitorWithManyTriggers.triggers.size)
     }
 }


### PR DESCRIPTION
### Description

Remove the hardcoded trigger count limit (`MONITOR_MAX_TRIGGERS = 10`) from the `Monitor` data class init block. Trigger count validation is moved to the alerting plugin, where it can be configured via a dynamic c
luster setting (`plugins.alerting.monitor.max_triggers`).

Companion alerting PR: https://github.com/opensearch-project/alerting/pull/2036


Resolves opensearch-project/alerting#468

### Related Issues
Resolves 
https://github.com/opensearch-project/alerting/issues/1828  
https://github.com/opensearch-project/alerting#468 

### Testing 

- Updated existing test to verify Monitor allows >10 triggers at the model level
- End-to-end tested with alerting plugin changes on a local cluster:
  - Default limit (10): 11 triggers rejected
  - Limit set to 20: 11 triggers accepted
  - Limit set to 5: 6 triggers rejected

```
Test 1 — Default limit (10), 11 triggers rejected:

# Generate 11 triggers
TRIGGERS=""
for i in $(seq 1 11); do
  if [ -n "$TRIGGERS" ]; then TRIGGERS="$TRIGGERS,"; fi
  TRIGGERS="$TRIGGERS{\"name\":\"trigger-$i\",\"severity\":\"1\",\"condition\":{\"script\":{\"source\":\"return true\",\"lang\":\"painless\"}},\"actions\":[]}"
done

curl -XPOST 'localhost:9200/_plugins/_alerting/monitors' -H 'Content-Type: application/json' -d "{
  \"type\": \"monitor\",
  \"name\": \"test-11-triggers\",
  \"monitor_type\": \"query_level_monitor\",
  \"enabled\": false,
  \"schedule\": {\"period\": {\"interval\": 10, \"unit\": \"MINUTES\"}},
  \"inputs\": [{\"search\": {\"indices\": [\"*\"], \"query\": {\"query\": {\"match_all\": {}}}}}],
  \"triggers\": [$TRIGGERS]
}"

# Response:
# { "error": { "reason": "Monitors can only support up to 10 triggers." }, "status": 400 }

est 2 — Increase limit to 20, 11 triggers accepted:

# Update setting
curl -XPUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d '{
  "persistent": {"plugins.alerting.monitor.max_triggers": 20}
}'
# Response: { "acknowledged": true }

# Same 11 triggers payload as above
# Response: 200 OK — monitor created

# Verify triggers stored
curl -s 'localhost:9200/_plugins/_alerting/monitors/<monitor_id>' | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Trigger count: {len(d[\"monitor\"][\"triggers\"])}')"
# Output: Trigger count: 11

Test 3 — Decrease limit to 5, 6 triggers rejected:

# Update setting
curl -XPUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d '{
  "persistent": {"plugins.alerting.monitor.max_triggers": 5}
}'
# Response: { "acknowledged": true }

# Generate 6 triggers
TRIGGERS=""
for i in $(seq 1 6); do
  if [ -n "$TRIGGERS" ]; then TRIGGERS="$TRIGGERS,"; fi
  TRIGGERS="$TRIGGERS{\"name\":\"trigger-$i\",\"severity\":\"1\",\"condition\":{\"script\":{\"source\":\"return true\",\"lang\":\"painless\"}},\"actions\":[]}"
done

curl -XPOST 'localhost:9200/_plugins/_alerting/monitors' -H 'Content-Type: application/json' -d "{
  \"type\": \"monitor\",
  \"name\": \"test-6-triggers\",
  \"monitor_type\": \"query_level_monitor\",
  \"enabled\": false,
  \"schedule\": {\"period\": {\"interval\": 10, \"unit\": \"MINUTES\"}},
  \"inputs\": [{\"search\": {\"indices\": [\"*\"], \"query\": {\"query\": {\"match_all\": {}}}}}],
  \"triggers\": [$TRIGGERS]
}"

# Response:
# { "error": { "reason": "Monitors can only support up to 5 triggers." }, "status": 400 }

```
### Check List
- [ X] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ X] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
