### PR TITLE
[Bug fix] Normalize cluster metrics input URI path during validation.

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInput.kt
@@ -147,8 +147,8 @@ data class ClusterMetricsInput(
                 }
             }
 
-            val formattedPath = path.trim('/')
-            if (apiType.isNotEmpty() && formattedPath.isNotEmpty()) {
+            if (apiType.isNotEmpty() && path.isNotEmpty()) {
+                val formattedPath = path.trim('/')
                 val derivedType = ClusterMetricType.values()
                     .filter { it != ClusterMetricType.BLANK }
                     .find { formattedPath.startsWith(it.prependPath.trim('/')) || formattedPath.startsWith(it.defaultPath.trim('/')) }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ClusterMetricsInputTests.kt
@@ -690,9 +690,9 @@ class ClusterMetricsInputTests {
     }
 
     @Test
-    fun `test parseInner skips api_type validation when path is only slashes`() {
-        // path "/" trims to "" so api_type validation is skipped;
-        // the url field drives construction instead
+    fun `test parseInner rejects slash-only path with api_type`() {
+        // path "/" enters validation since path.isNotEmpty(),
+        // but trimmed path doesn't match any ClusterMetricType
         val inputJson = """
             {"uri":{"api_type":"CAT_INDICES","path":"/","path_params":"","url":"http://localhost:9200/_cluster/health","clusters":[]}}
         """.trimIndent()
@@ -706,9 +706,8 @@ class ClusterMetricsInputTests {
         xcp.nextToken()
         xcp.nextToken()
 
-        // api_type says CAT_INDICES but url points to _cluster/health;
-        // since path trims to empty, the mismatch check is skipped and url is used
-        val input = ClusterMetricsInput.parseInner(xcp)
-        assertEquals(ClusterMetricsInput.ClusterMetricType.CLUSTER_HEALTH, input.clusterMetricType)
+        assertFailsWith<IllegalArgumentException>("The provided api_type") {
+            ClusterMetricsInput.parseInner(xcp)
+        }
     }
 }


### PR DESCRIPTION
### Description
PR https://github.com/opensearch-project/common-utils/pull/912 introduced an edge-case bug where an exception would be thrown if the input wasn't prepended with `/`. Normalizing cluster metrics input URI path during validation to resolve that bug.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
