### PR TITLE
Feature/monitor metadata scheduler fields

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/MonitorMetadata.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/MonitorMetadata.kt
@@ -26,7 +26,11 @@ data class MonitorMetadata(
     val lastActionExecutionTimes: List<ActionExecutionTime>,
     val lastRunContext: Map<String, Any>,
     // Maps (sourceIndex + monitorId) --> concreteQueryIndex
-    val sourceToQueryIndexMapping: MutableMap<String, String> = mutableMapOf()
+    val sourceToQueryIndexMapping: MutableMap<String, String> = mutableMapOf(),
+    /** Account ID where this monitor's external schedule was created. Null when external scheduling is not used. */
+    val schedulerAccountId: String? = null,
+    /** Region where this monitor's external schedule was created. Null when external scheduling is not used. */
+    val schedulerRegion: String? = null
 ) : Writeable, ToXContent {
 
     @Throws(IOException::class)
@@ -37,7 +41,10 @@ data class MonitorMetadata(
         monitorId = sin.readString(),
         lastActionExecutionTimes = sin.readList(ActionExecutionTime.Companion::readFrom),
         lastRunContext = Monitor.suppressWarning(sin.readMap()),
-        sourceToQueryIndexMapping = sin.readMap() as MutableMap<String, String>
+        sourceToQueryIndexMapping = sin.readMap() as MutableMap<String, String>,
+        // TODO: Add version guard once target release version is finalized
+        schedulerAccountId = sin.readOptionalString(),
+        schedulerRegion = sin.readOptionalString()
     )
 
     override fun writeTo(out: StreamOutput) {
@@ -48,6 +55,9 @@ data class MonitorMetadata(
         out.writeCollection(lastActionExecutionTimes)
         out.writeMap(lastRunContext)
         out.writeMap(sourceToQueryIndexMapping as MutableMap<String, Any>)
+        // TODO: Add version guard once target release version is finalized
+        out.writeOptionalString(schedulerAccountId)
+        out.writeOptionalString(schedulerRegion)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -59,6 +69,8 @@ data class MonitorMetadata(
         if (sourceToQueryIndexMapping.isNotEmpty()) {
             builder.field(SOURCE_TO_QUERY_INDEX_MAP_FIELD, sourceToQueryIndexMapping as MutableMap<String, Any>)
         }
+        if (schedulerAccountId != null) builder.field(SCHEDULER_ACCOUNT_ID_FIELD, schedulerAccountId)
+        if (schedulerRegion != null) builder.field(SCHEDULER_REGION_FIELD, schedulerRegion)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()
     }
@@ -69,6 +81,8 @@ data class MonitorMetadata(
         const val LAST_ACTION_EXECUTION_FIELD = "last_action_execution_times"
         const val LAST_RUN_CONTEXT_FIELD = "last_run_context"
         const val SOURCE_TO_QUERY_INDEX_MAP_FIELD = "source_to_query_index_mapping"
+        const val SCHEDULER_ACCOUNT_ID_FIELD = "scheduler_account_id"
+        const val SCHEDULER_REGION_FIELD = "scheduler_region"
 
         @JvmStatic
         @JvmOverloads
@@ -83,6 +97,8 @@ data class MonitorMetadata(
             val lastActionExecutionTimes = mutableListOf<ActionExecutionTime>()
             var lastRunContext: Map<String, Any> = mapOf()
             var sourceToQueryIndexMapping: MutableMap<String, String> = mutableMapOf()
+            var schedulerAccountId: String? = null
+            var schedulerRegion: String? = null
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -99,6 +115,8 @@ data class MonitorMetadata(
                     }
                     LAST_RUN_CONTEXT_FIELD -> lastRunContext = xcp.map()
                     SOURCE_TO_QUERY_INDEX_MAP_FIELD -> sourceToQueryIndexMapping = xcp.map() as MutableMap<String, String>
+                    SCHEDULER_ACCOUNT_ID_FIELD -> schedulerAccountId = xcp.text()
+                    SCHEDULER_REGION_FIELD -> schedulerRegion = xcp.text()
                 }
             }
 
@@ -109,7 +127,9 @@ data class MonitorMetadata(
                 monitorId = monitorId,
                 lastActionExecutionTimes = lastActionExecutionTimes,
                 lastRunContext = lastRunContext,
-                sourceToQueryIndexMapping = sourceToQueryIndexMapping
+                sourceToQueryIndexMapping = sourceToQueryIndexMapping,
+                schedulerAccountId = schedulerAccountId,
+                schedulerRegion = schedulerRegion
             )
         }
 

--- a/src/main/kotlin/org/opensearch/commons/alerting/util/MonitorPayloadBuilder.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/MonitorPayloadBuilder.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.util
+
+import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.commons.alerting.model.Monitor
+import org.opensearch.core.xcontent.ToXContent
+
+/**
+ * Builds the message payload for external schedule targets (e.g. SQS).
+ *
+ * Top-level fields for routing, nested monitorConfig with full monitor JSON.
+ */
+object MonitorPayloadBuilder {
+
+    /**
+     * @param jobStartTimePlaceholder scheduler-specific placeholder for execution time
+     *        (e.g. a context variable that the scheduler replaces at invocation time)
+     */
+    fun buildTargetInput(
+        monitor: Monitor,
+        appId: String,
+        tenantId: String,
+        workspaceId: String,
+        collectionEndpoint: String,
+        jobStartTimePlaceholder: String = ""
+    ): String {
+        val monitorConfigJson = serializeMonitorConfig(monitor)
+
+        val builder = XContentFactory.jsonBuilder()
+        builder.startObject()
+        if (jobStartTimePlaceholder.isNotEmpty()) {
+            builder.field("job_start_time", jobStartTimePlaceholder)
+        }
+        builder.field("appId", appId)
+        builder.field("tenantId", tenantId)
+        builder.field("monitorId", monitor.id)
+        builder.field("workspaceId", workspaceId)
+        builder.field("collectionEndpoint", collectionEndpoint)
+        builder.field("monitorConfig", monitorConfigJson)
+        builder.endObject()
+        return builder.toString()
+    }
+
+    private fun serializeMonitorConfig(monitor: Monitor): String {
+        val builder = XContentFactory.jsonBuilder()
+        monitor.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        return builder.toString()
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/alerting/util/ScheduleTranslator.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/ScheduleTranslator.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.util
+
+import org.opensearch.commons.alerting.model.CronSchedule
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import org.opensearch.commons.alerting.model.Schedule
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Translates OpenSearch [Schedule] (CronSchedule / IntervalSchedule) to
+ * EventBridge Scheduler expression strings.
+ *
+ * EB rate: rate(value unit)  — unit is minute(s)|hour(s)|day(s)
+ * EB cron: cron(min hour dom month dow year) — 6 fields, ? for mutual exclusion
+ *
+ * OpenSearch cron is standard Unix 5-field: min hour dom month dow
+ * OpenSearch day-of-week: 0=Sun (cron-utils UNIX type)
+ * EB day-of-week: 1=Sun..7=Sat
+ */
+object ScheduleTranslator {
+
+    /**
+     * Returns the EB ScheduleExpression string and optional timezone.
+     * Timezone is only non-null for CronSchedule.
+     */
+    fun toEventBridgeExpression(schedule: Schedule): Pair<String, ZoneId?> {
+        return when (schedule) {
+            is IntervalSchedule -> Pair(translateInterval(schedule), null)
+            is CronSchedule -> Pair(translateCron(schedule), schedule.timezone)
+        }
+    }
+
+    private fun translateInterval(schedule: IntervalSchedule): String {
+        val unit = when (schedule.unit) {
+            ChronoUnit.SECONDS -> {
+                if (schedule.interval < 60) {
+                    throw IllegalArgumentException(
+                        "EventBridge Scheduler does not support intervals less than 1 minute. " +
+                            "Got ${schedule.interval} seconds."
+                    )
+                }
+                val minutes = (schedule.interval + 59) / 60
+                return "rate($minutes ${if (minutes == 1) "minute" else "minutes"})"
+            }
+            ChronoUnit.MINUTES -> if (schedule.interval == 1) "minute" else "minutes"
+            ChronoUnit.HOURS -> if (schedule.interval == 1) "hour" else "hours"
+            ChronoUnit.DAYS -> if (schedule.interval == 1) "day" else "days"
+            else -> throw IllegalArgumentException("Unsupported interval unit: ${schedule.unit}")
+        }
+        return "rate(${schedule.interval} $unit)"
+    }
+
+    private fun translateCron(schedule: CronSchedule): String {
+        val parts = schedule.expression.trim().split("\\s+".toRegex())
+        require(parts.size == 5) { "Expected 5-field cron expression, got ${parts.size}: ${schedule.expression}" }
+
+        val (min, hour, dom, month, dow) = parts
+        val (ebDom, ebDow) = resolveDomDow(dom, translateDayOfWeek(dow))
+
+        return "cron($min $hour $ebDom $month $ebDow *)"
+    }
+
+    /**
+     * Translates Unix cron day-of-week to EB day-of-week.
+     * Unix (cron-utils UNIX): 0=Sun, 1=Mon..6=Sat
+     * EB Scheduler: 1=Sun, 2=Mon..7=Sat
+     */
+    private fun translateDayOfWeek(dow: String): String {
+        if (dow == "*") return "*"
+
+        return dow.split(",").joinToString(",") { part ->
+            when {
+                part.contains("-") -> {
+                    val (start, end) = part.split("-", limit = 2)
+                    "${unixDowToEb(start)}-${unixDowToEb(end)}"
+                }
+                part.contains("/") -> {
+                    val (base, step) = part.split("/", limit = 2)
+                    val ebBase = if (base == "*") "*" else unixDowToEb(base)
+                    "$ebBase/$step"
+                }
+                else -> unixDowToEb(part)
+            }
+        }
+    }
+
+    private fun unixDowToEb(value: String): String {
+        val num = value.toIntOrNull() ?: return value
+        return ((num % 7) + 1).toString()
+    }
+
+    private fun resolveDomDow(dom: String, dow: String): Pair<String, String> {
+        val domIsWild = dom == "*" || dom == "?"
+        val dowIsWild = dow == "*" || dow == "?"
+        return when {
+            !domIsWild && !dowIsWild -> Pair(dom, "?")
+            !domIsWild -> Pair(dom, "?")
+            !dowIsWild -> Pair("?", dow)
+            else -> Pair("*", "?")
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -1,6 +1,7 @@
 package org.opensearch.commons.alerting.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.opensearch.common.io.stream.BytesStreamOutput
@@ -527,6 +528,40 @@ class XContentTests {
         val monitorMetadataString = monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
         val parsedMonitorMetadata = MonitorMetadata.parse(parser(monitorMetadataString))
         assertEquals("Round tripping MonitorMetadata doesn't work", monitorMetadata, parsedMonitorMetadata)
+    }
+
+    @Test
+    fun `test MonitorMetadata with scheduler fields`() {
+        val monitorMetadata = MonitorMetadata(
+            id = "monitorId-metadata",
+            monitorId = "monitorId",
+            lastActionExecutionTimes = emptyList(),
+            lastRunContext = emptyMap(),
+            sourceToQueryIndexMapping = mutableMapOf(),
+            schedulerAccountId = "123456789012",
+            schedulerRegion = "us-west-2"
+        )
+        val monitorMetadataString = monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedMonitorMetadata = MonitorMetadata.parse(parser(monitorMetadataString))
+        assertEquals("Round tripping MonitorMetadata with scheduler fields doesn't work", monitorMetadata, parsedMonitorMetadata)
+        assertEquals("123456789012", parsedMonitorMetadata.schedulerAccountId)
+        assertEquals("us-west-2", parsedMonitorMetadata.schedulerRegion)
+    }
+
+    @Test
+    fun `test MonitorMetadata without scheduler fields is backward compatible`() {
+        val monitorMetadata = MonitorMetadata(
+            id = "monitorId-metadata",
+            monitorId = "monitorId",
+            lastActionExecutionTimes = emptyList(),
+            lastRunContext = emptyMap(),
+            sourceToQueryIndexMapping = mutableMapOf()
+        )
+        val monitorMetadataString = monitorMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS).string()
+        val parsedMonitorMetadata = MonitorMetadata.parse(parser(monitorMetadataString))
+        assertEquals("Round tripping MonitorMetadata without scheduler fields doesn't work", monitorMetadata, parsedMonitorMetadata)
+        assertNull(parsedMonitorMetadata.schedulerAccountId)
+        assertNull(parsedMonitorMetadata.schedulerRegion)
     }
 
     @Test

--- a/src/test/kotlin/org/opensearch/commons/alerting/util/ScheduleTranslatorTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/util/ScheduleTranslatorTests.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.opensearch.commons.alerting.model.CronSchedule
+import org.opensearch.commons.alerting.model.IntervalSchedule
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+class ScheduleTranslatorTests {
+
+    @Test
+    fun `translate 1 minute interval`() {
+        val schedule = IntervalSchedule(1, ChronoUnit.MINUTES)
+        val (expr, tz) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(1 minute)", expr)
+        assertNull(tz)
+    }
+
+    @Test
+    fun `translate 5 minutes interval`() {
+        val schedule = IntervalSchedule(5, ChronoUnit.MINUTES)
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(5 minutes)", expr)
+    }
+
+    @Test
+    fun `translate 1 hour interval`() {
+        val schedule = IntervalSchedule(1, ChronoUnit.HOURS)
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(1 hour)", expr)
+    }
+
+    @Test
+    fun `translate 1 day interval`() {
+        val schedule = IntervalSchedule(1, ChronoUnit.DAYS)
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(1 day)", expr)
+    }
+
+    @Test
+    fun `translate seconds interval converts to minutes`() {
+        val schedule = IntervalSchedule(120, ChronoUnit.SECONDS)
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(2 minutes)", expr)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `translate sub-minute seconds interval throws`() {
+        val schedule = IntervalSchedule(30, ChronoUnit.SECONDS)
+        ScheduleTranslator.toEventBridgeExpression(schedule)
+    }
+
+    @Test
+    fun `translate non-divisible seconds uses ceiling division`() {
+        val schedule = IntervalSchedule(90, ChronoUnit.SECONDS)
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("rate(2 minutes)", expr)
+    }
+
+    @Test
+    fun `translate every 5 hours cron`() {
+        val schedule = CronSchedule("0 */5 * * *", ZoneId.of("UTC"))
+        val (expr, tz) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("cron(0 */5 * * ? *)", expr)
+        assertEquals(ZoneId.of("UTC"), tz)
+    }
+
+    @Test
+    fun `translate weekday cron with dow range`() {
+        val schedule = CronSchedule("0 0 * * 1-5", ZoneId.of("US/Pacific"))
+        val (expr, tz) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("cron(0 0 ? * 2-6 *)", expr)
+        assertEquals(ZoneId.of("US/Pacific"), tz)
+    }
+
+    @Test
+    fun `translate specific dom`() {
+        val schedule = CronSchedule("0 0 1 * *", ZoneId.of("UTC"))
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("cron(0 0 1 * ? *)", expr)
+    }
+
+    @Test
+    fun `translate dow list`() {
+        val schedule = CronSchedule("0 9 * * 0,6", ZoneId.of("UTC"))
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("cron(0 9 ? * 1,7 *)", expr)
+    }
+
+    @Test
+    fun `translate Sunday as 0`() {
+        val schedule = CronSchedule("0 0 * * 0", ZoneId.of("UTC"))
+        val (expr, _) = ScheduleTranslator.toEventBridgeExpression(schedule)
+        assertEquals("cron(0 0 ? * 1 *)", expr)
+    }
+}


### PR DESCRIPTION
Adds two optional fields to MonitorMetadata:
- schedulerAccountId: accountId where the monitor's external schedule was created
- schedulerRegion: region where the external schedule was created

These fields allow the alerting plugin to read back the scheduler account info from monitor metadata during delete/update operations, ensuring the correct external schedule is targeted even if cluster settings change.

Both fields are nullable with null defaults for full backward compatibility. Existing monitors without external scheduling are unaffected.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
