### PR TITLE
feat: Add ScheduleJobPayload POJO for external monitor scheduling

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayload.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayload.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.model
+
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.core.xcontent.NamedXContentRegistry
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.ToXContentObject
+import org.opensearch.core.xcontent.XContentBuilder
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.core.xcontent.XContentParserUtils
+import java.time.Instant
+
+/**
+ * Represents the payload for an externally scheduled monitor job.
+ *
+ * Written to the schedule target (e.g. SQS) by the monitor CRUD path,
+ * and parsed back by the job poller at execution time.
+ */
+data class ScheduleJobPayload(
+    val monitorId: String,
+    val jobStartTime: Instant,
+    val monitorConfig: String
+) : ToXContentObject {
+
+    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
+        builder.startObject()
+        builder.field(MONITOR_ID_FIELD, monitorId)
+        builder.field(JOB_START_TIME_FIELD, jobStartTime.toString())
+        builder.field(MONITOR_CONFIG_FIELD, monitorConfig)
+        builder.endObject()
+        return builder
+    }
+
+    /**
+     * Deserializes [monitorConfig] into a [Monitor] using the provided registry.
+     * The [monitorId] is passed through so the monitor retains its identity.
+     */
+    fun toMonitor(xContentRegistry: NamedXContentRegistry): Monitor {
+        return XContentType.JSON.xContent()
+            .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, monitorConfig)
+            .use { parser ->
+                parser.nextToken()
+                Monitor.parse(parser, monitorId, Monitor.NO_VERSION)
+            }
+    }
+
+    companion object {
+        const val MONITOR_ID_FIELD = "monitorId"
+        const val JOB_START_TIME_FIELD = "job_start_time"
+        const val MONITOR_CONFIG_FIELD = "monitorConfig"
+
+        fun parse(xcp: XContentParser): ScheduleJobPayload {
+            var monitorId: String? = null
+            var jobStartTime: Instant? = null
+            var monitorConfig: String? = null
+
+            XContentParserUtils.ensureExpectedToken(
+                XContentParser.Token.START_OBJECT,
+                xcp.currentToken(),
+                xcp
+            )
+            while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                val fieldName = xcp.currentName()
+                xcp.nextToken()
+                when (fieldName) {
+                    MONITOR_ID_FIELD -> monitorId = xcp.text()
+                    JOB_START_TIME_FIELD -> jobStartTime = Instant.parse(xcp.text())
+                    MONITOR_CONFIG_FIELD -> monitorConfig = xcp.text()
+                    else -> xcp.skipChildren()
+                }
+            }
+
+            return ScheduleJobPayload(
+                monitorId = requireNotNull(monitorId) { "Payload missing $MONITOR_ID_FIELD field" },
+                jobStartTime = requireNotNull(jobStartTime) { "Payload missing $JOB_START_TIME_FIELD field" },
+                monitorConfig = requireNotNull(monitorConfig) { "Payload missing $MONITOR_CONFIG_FIELD field" }
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayloadTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayloadTests.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.alerting.model
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.alerting.parser
+import org.opensearch.commons.alerting.randomQueryLevelMonitor
+import org.opensearch.commons.alerting.xContentRegistry
+import org.opensearch.core.xcontent.ToXContent
+import java.time.Instant
+
+class ScheduleJobPayloadTests {
+
+    private fun serializeMonitor(monitor: Monitor): String {
+        val builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder()
+        monitor.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        return builder.toString()
+    }
+
+    @Test
+    fun `round-trip with monitorId and jobStartTime`() {
+        val monitor = randomQueryLevelMonitor().copy(id = "mon-123")
+        val payload = ScheduleJobPayload(
+            monitorId = monitor.id,
+            jobStartTime = Instant.parse("2026-04-23T10:00:00Z"),
+            monitorConfig = serializeMonitor(monitor)
+        )
+
+        val builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder()
+        payload.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+
+        val parsed = ScheduleJobPayload.parse(parser(json))
+        assertEquals("mon-123", parsed.monitorId)
+        assertEquals(Instant.parse("2026-04-23T10:00:00Z"), parsed.jobStartTime)
+        assertEquals(payload.monitorConfig, parsed.monitorConfig)
+    }
+
+    @Test
+    fun `toMonitor preserves id and fields`() {
+        val monitor = randomQueryLevelMonitor().copy(id = "mon-456")
+        val payload = ScheduleJobPayload(
+            monitorId = monitor.id,
+            jobStartTime = Instant.now(),
+            monitorConfig = serializeMonitor(monitor)
+        )
+
+        val restored = payload.toMonitor(xContentRegistry())
+        assertEquals("mon-456", restored.id)
+        assertEquals(monitor.name, restored.name)
+        assertEquals(monitor.monitorType, restored.monitorType)
+    }
+
+    @Test
+    fun `toMonitor preserves metadata`() {
+        val monitor = randomQueryLevelMonitor().copy(
+            id = "mon-meta",
+            metadata = mapOf("appId" to "app1", "tenantId" to "t1")
+        )
+        val payload = ScheduleJobPayload(
+            monitorId = monitor.id,
+            jobStartTime = Instant.now(),
+            monitorConfig = serializeMonitor(monitor)
+        )
+
+        val restored = payload.toMonitor(xContentRegistry())
+        assertEquals(
+            mapOf("appId" to "app1", "tenantId" to "t1"),
+            restored.metadata
+        )
+    }
+
+    @Test
+    fun `parse throws on missing monitorId`() {
+        val monitor = randomQueryLevelMonitor()
+        val json = "{\"job_start_time\":\"2026-04-23T10:00:00Z\"," +
+            "\"monitorConfig\":\"${serializeMonitor(monitor).replace("\"", "\\\"")}\"}"
+
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            ScheduleJobPayload.parse(parser(json))
+        }
+    }
+}


### PR DESCRIPTION
Written to the schedule target (e.g. SQS) by the monitor CRUD path, and parsed back by the sqs  job poller at execution time in background.
- Add monitorId as top-level field in buildTargetInput when monitor has a non-empty id
- Add parseTargetInput() to deserialize payload back into Monitor + jobStartTime, passing monitorId to Monitor.parse() so the id survives the serialization round-trip
- Extract field name constants

