### PR TITLE
Hide metadata field from REST API responses using secure flag

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Monitor.kt
@@ -189,6 +189,7 @@ data class Monitor(
 
         if (!secure) {
             builder.optionalUserField(USER_FIELD, user)
+            if (!metadata.isNullOrEmpty()) builder.field(METADATA_FIELD, metadata)
         }
 
         builder.field(ENABLED_FIELD, enabled)
@@ -202,7 +203,6 @@ data class Monitor(
         builder.field(DELETE_QUERY_INDEX_IN_EVERY_RUN_FIELD, deleteQueryIndexInEveryRun)
         builder.field(SHOULD_CREATE_SINGLE_ALERT_FOR_FINDINGS_FIELD, shouldCreateSingleAlertForFindings)
         builder.field(OWNER_FIELD, owner)
-        if (!metadata.isNullOrEmpty()) builder.field(METADATA_FIELD, metadata)
         if (target != null) builder.field(TARGET_FIELD, target)
         if (params.paramAsBoolean("with_type", false)) builder.endObject()
         return builder.endObject()

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayloadTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/ScheduleJobPayloadTests.kt
@@ -16,7 +16,7 @@ class ScheduleJobPayloadTests {
 
     private fun serializeMonitor(monitor: Monitor): String {
         val builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder()
-        monitor.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        monitor.toXContentWithUser(builder, ToXContent.EMPTY_PARAMS)
         return builder.toString()
     }
 


### PR DESCRIPTION
Move metadata serialization inside the !secure block in Monitor.createXContentBuilder() so it is excluded from customer-facing REST responses (toXContent with secure=true) while still included in internal paths like index persistence and SQS payloads (toXContentWithUser with secure=false). This follows the same pattern used for the user field.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
