### PR TITLE
feat: Expose bucketsPathsMap in BucketSelectorExtAggregationBuilder

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/aggregation/bucketselectorext/BucketSelectorExtAggregationBuilder.kt
@@ -20,7 +20,7 @@ import kotlin.collections.HashMap
 
 class BucketSelectorExtAggregationBuilder :
     AbstractPipelineAggregationBuilder<BucketSelectorExtAggregationBuilder> {
-    private val bucketsPathsMap: Map<String, String>
+    val bucketsPathsMap: Map<String, String>
     val parentBucketPath: String
     val script: Script
     val filter: BucketSelectorExtFilter?


### PR DESCRIPTION
Make bucketsPathsMap publicly accessible so that callers can read the trigger's bucket paths This is needed by the alerting plugin to translate BucketSelectorExt into a standard bucket_selector for remote trigger evaluation.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
