### PR TITLE
Mark webhook-channel configs as encrypted

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConstants.kt
@@ -69,4 +69,5 @@ object NotificationConstants {
     const val PLUGIN_FEATURES_TAG = "plugin_features"
 
     const val DEFAULT_MAX_ITEMS = 1000
+    const val ENCRYPTION_PREFIX = "enc:"
 }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
@@ -21,13 +21,12 @@ import java.io.IOException
  * Data class representing Chime channel.
  */
 data class Chime(
-    val url: String,
-    val isEncrypted: Boolean = false
+    val url: String
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!isEncrypted) {
+        if (!url.startsWith("enc:")) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
@@ -4,6 +4,7 @@
  */
 package org.opensearch.commons.notifications.model
 
+import org.opensearch.commons.notifications.NotificationConstants.ENCRYPTION_PREFIX
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
 import org.opensearch.commons.utils.logger
 import org.opensearch.commons.utils.validateUrl
@@ -26,7 +27,7 @@ data class Chime(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!url.startsWith("enc:")) {
+        if (!url.startsWith(ENCRYPTION_PREFIX)) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
@@ -21,12 +21,15 @@ import java.io.IOException
  * Data class representing Chime channel.
  */
 data class Chime(
-    val url: String
+    val url: String,
+    val isEncrypted: Boolean = false
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        if (!isEncrypted) {
+            validateUrl(url)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
@@ -21,12 +21,15 @@ import java.io.IOException
  * Data class representing MicrosoftTeams channel.
  */
 data class MicrosoftTeams(
-    val url: String
+    val url: String,
+    val isEncrypted: Boolean = false
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        if (!isEncrypted) {
+            validateUrl(url)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
@@ -4,6 +4,7 @@
  */
 package org.opensearch.commons.notifications.model
 
+import org.opensearch.commons.notifications.NotificationConstants.ENCRYPTION_PREFIX
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
 import org.opensearch.commons.utils.logger
 import org.opensearch.commons.utils.validateUrl
@@ -26,7 +27,7 @@ data class MicrosoftTeams(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!url.startsWith("enc:")) {
+        if (!url.startsWith(ENCRYPTION_PREFIX)) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
@@ -21,13 +21,12 @@ import java.io.IOException
  * Data class representing MicrosoftTeams channel.
  */
 data class MicrosoftTeams(
-    val url: String,
-    val isEncrypted: Boolean = false
+    val url: String
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!isEncrypted) {
+        if (!url.startsWith("enc:")) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
@@ -21,12 +21,15 @@ import java.io.IOException
  * Data class representing Slack channel.
  */
 data class Slack(
-    val url: String
+    val url: String,
+    val isEncrypted: Boolean = false
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        if (!isEncrypted) {
+            validateUrl(url)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
@@ -4,6 +4,7 @@
  */
 package org.opensearch.commons.notifications.model
 
+import org.opensearch.commons.notifications.NotificationConstants.ENCRYPTION_PREFIX
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
 import org.opensearch.commons.utils.logger
 import org.opensearch.commons.utils.validateUrl
@@ -26,7 +27,7 @@ data class Slack(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!url.startsWith("enc:")) {
+        if (!url.startsWith(ENCRYPTION_PREFIX)) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
@@ -21,13 +21,12 @@ import java.io.IOException
  * Data class representing Slack channel.
  */
 data class Slack(
-    val url: String,
-    val isEncrypted: Boolean = false
+    val url: String
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!isEncrypted) {
+        if (!url.startsWith("enc:")) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
@@ -27,13 +27,12 @@ import java.io.IOException
 data class Webhook(
     val url: String,
     val headerParams: Map<String, String> = mapOf(),
-    val method: HttpMethodType = HttpMethodType.POST,
-    val isEncrypted: Boolean = false
+    val method: HttpMethodType = HttpMethodType.POST
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!isEncrypted) {
+        if (!url.startsWith("enc:")) {
             validateUrl(url)
         }
     }

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
@@ -27,12 +27,15 @@ import java.io.IOException
 data class Webhook(
     val url: String,
     val headerParams: Map<String, String> = mapOf(),
-    val method: HttpMethodType = HttpMethodType.POST
+    val method: HttpMethodType = HttpMethodType.POST,
+    val isEncrypted: Boolean = false
 ) : BaseConfigData {
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        if (!isEncrypted) {
+            validateUrl(url)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
@@ -4,6 +4,7 @@
  */
 package org.opensearch.commons.notifications.model
 
+import org.opensearch.commons.notifications.NotificationConstants.ENCRYPTION_PREFIX
 import org.opensearch.commons.notifications.NotificationConstants.HEADER_PARAMS_TAG
 import org.opensearch.commons.notifications.NotificationConstants.METHOD_TAG
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
@@ -32,7 +33,7 @@ data class Webhook(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        if (!url.startsWith("enc:")) {
+        if (!url.startsWith(ENCRYPTION_PREFIX)) {
             validateUrl(url)
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/ChimeTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/ChimeTests.kt
@@ -77,6 +77,28 @@ internal class ChimeTests {
     }
 
     @Test
+    fun `Chime should skip url validation when url starts with enc prefix`() {
+        val encryptedUrl = "enc:this-is-not-a-real-url"
+        val chime = Chime(encryptedUrl)
+        assertEquals(encryptedUrl, chime.url)
+    }
+
+    @Test
+    fun `Chime with enc prefix should serialize and deserialize transport object`() {
+        val sampleChime = Chime("enc:some-encrypted-value")
+        val recreatedObject = recreateObject(sampleChime) { Chime(it) }
+        assertEquals(sampleChime, recreatedObject)
+    }
+
+    @Test
+    fun `Chime with enc prefix should serialize and deserialize using json object`() {
+        val sampleChime = Chime("enc:some-encrypted-value")
+        val jsonString = getJsonString(sampleChime)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Chime.parse(it) }
+        assertEquals(sampleChime, recreatedObject)
+    }
+
+    @Test
     fun `Chime should safely ignore extra field in json object`() {
         val sampleChime = Chime("https://domain.com/sample_url#1234567890")
         val jsonString = "{\"url\":\"${sampleChime.url}\", \"another\":\"field\"}"

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeamsTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeamsTests.kt
@@ -77,6 +77,28 @@ internal class MicrosoftTeamsTests {
     }
 
     @Test
+    fun `Microsoft Teams should skip url validation when url starts with enc prefix`() {
+        val encryptedUrl = "enc:this-is-not-a-real-url"
+        val microsoftTeams = MicrosoftTeams(encryptedUrl)
+        assertEquals(encryptedUrl, microsoftTeams.url)
+    }
+
+    @Test
+    fun `Microsoft Teams with enc prefix should serialize and deserialize transport object`() {
+        val sampleMicrosoftTeams = MicrosoftTeams("enc:some-encrypted-value")
+        val recreatedObject = recreateObject(sampleMicrosoftTeams) { MicrosoftTeams(it) }
+        assertEquals(sampleMicrosoftTeams, recreatedObject)
+    }
+
+    @Test
+    fun `Microsoft Teams with enc prefix should serialize and deserialize using json object`() {
+        val sampleMicrosoftTeams = MicrosoftTeams("enc:some-encrypted-value")
+        val jsonString = getJsonString(sampleMicrosoftTeams)
+        val recreatedObject = createObjectFromJsonString(jsonString) { MicrosoftTeams.parse(it) }
+        assertEquals(sampleMicrosoftTeams, recreatedObject)
+    }
+
+    @Test
     fun `Microsoft Teams should safely ignore extra field in json object`() {
         val sampleMicrosoftTeams = MicrosoftTeams("https://domain.com/sample_url#1234567890")
         val jsonString = "{\"url\":\"${sampleMicrosoftTeams.url}\", \"another\":\"field\"}"

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/SlackTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/SlackTests.kt
@@ -77,6 +77,28 @@ internal class SlackTests {
     }
 
     @Test
+    fun `Slack should skip url validation when url starts with enc prefix`() {
+        val encryptedUrl = "enc:this-is-not-a-real-url"
+        val slack = Slack(encryptedUrl)
+        assertEquals(encryptedUrl, slack.url)
+    }
+
+    @Test
+    fun `Slack with enc prefix should serialize and deserialize transport object`() {
+        val sampleSlack = Slack("enc:some-encrypted-value")
+        val recreatedObject = recreateObject(sampleSlack) { Slack(it) }
+        assertEquals(sampleSlack, recreatedObject)
+    }
+
+    @Test
+    fun `Slack with enc prefix should serialize and deserialize using json object`() {
+        val sampleSlack = Slack("enc:some-encrypted-value")
+        val jsonString = getJsonString(sampleSlack)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Slack.parse(it) }
+        assertEquals(sampleSlack, recreatedObject)
+    }
+
+    @Test
     fun `Slack should safely ignore extra field in json object`() {
         val sampleSlack = Slack("https://domain.com/sample_url#1234567890")
         val jsonString = "{\"url\":\"${sampleSlack.url}\", \"another\":\"field\"}"

--- a/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/model/WebhookTests.kt
@@ -93,6 +93,28 @@ internal class WebhookTests {
     }
 
     @Test
+    fun `Webhook should skip url validation when url starts with enc prefix`() {
+        val encryptedUrl = "enc:this-is-not-a-real-url"
+        val webhook = Webhook(encryptedUrl)
+        assertEquals(encryptedUrl, webhook.url)
+    }
+
+    @Test
+    fun `Webhook with enc prefix should serialize and deserialize transport object`() {
+        val sampleWebhook = Webhook("enc:some-encrypted-value")
+        val recreatedObject = recreateObject(sampleWebhook) { Webhook(it) }
+        assertEquals(sampleWebhook, recreatedObject)
+    }
+
+    @Test
+    fun `Webhook with enc prefix should serialize and deserialize using json object`() {
+        val sampleWebhook = Webhook("enc:some-encrypted-value")
+        val jsonString = getJsonString(sampleWebhook)
+        val recreatedObject = createObjectFromJsonString(jsonString) { Webhook.parse(it) }
+        assertEquals(sampleWebhook, recreatedObject)
+    }
+
+    @Test
     fun `Webhook should safely ignore extra field in json object`() {
         val sampleWebhook = Webhook("https://domain.com/sample_url#1234567890")
         val jsonString = "{\"url\":\"${sampleWebhook.url}\", \"another\":\"field\"}"


### PR DESCRIPTION
### Mark webhook-channel configs as encrypted

This PR supports the effort to [encrypt notification channel configurations](https://github.com/opensearch-project/notifications/pull/1218) in the OpenSearch Notification-Plugin.

It checks if the url for a webhook channel is encrypted and skips url-validation if this is the case.

### Caveats

This introduces external knowledge into the utility project (How encrypted urls are prefixed). An alternative would be, creating dedicated types for encrypted webhook configs inside the notification project.

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
