### PR TITLE
temporarily putting PPL Alerting serde behind 3.6 check

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Alert.kt
@@ -417,12 +417,14 @@ data class Alert(
         executionId = sin.readOptionalString(),
         associatedAlertIds = sin.readStringList(),
         clusters = sin.readOptionalStringList(),
-        query = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        query = if (sin.version.onOrAfter(Version.V_3_6_0)) {
             sin.readOptionalString()
         } else {
             null
         },
-        queryResults = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        queryResults = if (sin.version.onOrAfter(Version.V_3_6_0)) {
             sin.readList { input -> suppressWarning(input.readMap()) }
         } else {
             listOf()
@@ -470,7 +472,8 @@ data class Alert(
         out.writeOptionalString(executionId)
         out.writeStringCollection(associatedAlertIds)
         out.writeOptionalStringArray(clusters?.toTypedArray())
-        if (out.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        if (out.version.onOrAfter(Version.V_3_6_0)) {
             out.writeOptionalString(query)
             out.writeCollection(queryResults) { output, map ->
                 output.writeMap(map)

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/MonitorRunResult.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/MonitorRunResult.kt
@@ -129,7 +129,8 @@ data class InputRunResults(
             out.writeMap(map)
         }
 
-        if (out.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        if (out.version.onOrAfter(Version.V_3_6_0)) {
             out.writeVInt(pplBaseQueryResults.size)
             for (datarow in pplBaseQueryResults) {
                 out.writeMap(datarow)
@@ -149,18 +150,21 @@ data class InputRunResults(
             for (i in 0 until count) {
                 list.add(suppressWarning(sin.readMap())) // result(map)
             }
-            val pplCount = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+            // TODO: change to 3.7 when alerting version bump happens
+            val pplCount = if (sin.version.onOrAfter(Version.V_3_6_0)) {
                 sin.readVInt()
             } else {
                 0
             }
             val pplList = mutableListOf<Map<String, Any?>>()
-            if (sin.version.onOrAfter(Version.V_3_7_0)) {
+            // TODO: change to 3.7 when alerting version bump happens
+            if (sin.version.onOrAfter(Version.V_3_6_0)) {
                 for (i in 0 until pplCount) {
                     pplList.add(suppressWarning(sin.readMap())) // pplResults
                 }
             }
-            val pplNumResults = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+            // TODO: change to 3.7 when alerting version bump happens
+            val pplNumResults = if (sin.version.onOrAfter(Version.V_3_6_0)) {
                 sin.readOptionalLong()
             } else {
                 null

--- a/src/main/kotlin/org/opensearch/commons/alerting/model/QueryLevelTriggerRunResult.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/QueryLevelTriggerRunResult.kt
@@ -30,7 +30,8 @@ open class QueryLevelTriggerRunResult(
         error = sin.readException(),
         triggered = sin.readBoolean(),
         actionResults = sin.readMap() as MutableMap<String, ActionRunResult>,
-        pplCustomQueryResults = if (sin.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        pplCustomQueryResults = if (sin.version.onOrAfter(Version.V_3_6_0)) {
             sin.readList { it.readMap() }
         } else {
             listOf()
@@ -62,7 +63,8 @@ open class QueryLevelTriggerRunResult(
         super.writeTo(out)
         out.writeBoolean(triggered)
         out.writeMap(actionResults as Map<String, ActionRunResult>)
-        if (out.version.onOrAfter(Version.V_3_7_0)) {
+        // TODO: change to 3.7 when alerting version bump happens
+        if (out.version.onOrAfter(Version.V_3_6_0)) {
             out.writeCollection(pplCustomQueryResults) { stream, map -> stream.writeMap(map) }
         }
     }


### PR DESCRIPTION
Temporarily putting PPL Alerting fields under 3.6 until Alerting version is bumped to 3.7.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
