### PR TITLE
feat: Preserve tenant ID header across SecureClientWrapper stash

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/utils/SecureClientWrapper.kt
+++ b/src/main/kotlin/org/opensearch/commons/utils/SecureClientWrapper.kt
@@ -41,10 +41,27 @@ import org.opensearch.core.action.ActionResponse
 import org.opensearch.transport.client.Client
 
 /**
- * Wrapper class on [Client] with security context removed.
+ * Wrapper class on [Client] with security context removed but tenant context preserved for notifications.
  */
 @Suppress("TooManyFunctions")
 class SecureClientWrapper(private val client: Client) : Client by client {
+
+    companion object {
+        const val TENANT_ID_HEADER = "x-tenant-id"
+    }
+
+    /**
+     * Stashes the current thread context but preserves the tenant ID header.
+     * Used only for execute() which is the path for notification transport actions.
+     */
+    private inline fun <R> stashAndPreserveTenant(block: () -> R): R {
+        val tenantId = client.threadPool().threadContext.getHeader(TENANT_ID_HEADER)
+        client.threadPool().threadContext.stashContext().use {
+            tenantId?.let { client.threadPool().threadContext.putHeader(TENANT_ID_HEADER, it) }
+            return block()
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -52,7 +69,7 @@ class SecureClientWrapper(private val client: Client) : Client by client {
         action: ActionType<Response>,
         request: Request
     ): ActionFuture<Response> {
-        client.threadPool().threadContext.stashContext().use { return client.execute(action, request) }
+        return stashAndPreserveTenant { client.execute(action, request) }
     }
 
     /**
@@ -63,7 +80,7 @@ class SecureClientWrapper(private val client: Client) : Client by client {
         request: Request,
         listener: ActionListener<Response>
     ) {
-        client.threadPool().threadContext.stashContext().use { return client.execute(action, request, listener) }
+        stashAndPreserveTenant { client.execute(action, request, listener) }
     }
 
     /**

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationsPluginInterfaceTests.kt
@@ -227,6 +227,82 @@ internal class NotificationsPluginInterfaceTests {
         verify(l, times(1)).onResponse(eq(res))
     }
 
+    @Test
+    fun `sendNotification preserves tenant id header through SecureClientWrapper`() {
+        val threadContext = org.opensearch.common.util.concurrent.ThreadContext(
+            org.opensearch.common.settings.Settings.EMPTY
+        )
+        val realClient = mock(NodeClient::class.java)
+        val threadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        whenever(realClient.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        // Set tenant ID header before calling sendNotification
+        threadContext.putHeader("x-tenant-id", "tenant-notify-test")
+
+        val notificationInfo = EventSource("title", "ref_id", SeverityType.HIGH, listOf("tag"))
+        val channelMessage = ChannelMessage("message", null, null)
+        val listener: ActionListener<SendNotificationResponse> =
+            mock(ActionListener::class.java) as ActionListener<SendNotificationResponse>
+
+        var capturedTenantId: String? = null
+        doAnswer {
+            // Capture the tenant ID header at the point of the actual transport execute call
+            capturedTenantId = threadContext.getHeader("x-tenant-id")
+            null
+        }.whenever(realClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.sendNotification(
+            realClient,
+            notificationInfo,
+            channelMessage,
+            listOf("channel-1"),
+            listener
+        )
+
+        org.junit.jupiter.api.Assertions.assertEquals("tenant-notify-test", capturedTenantId)
+    }
+
+    @Test
+    fun `sendNotification stashes security context but keeps tenant id`() {
+        val threadContext = org.opensearch.common.util.concurrent.ThreadContext(
+            org.opensearch.common.settings.Settings.EMPTY
+        )
+        val realClient = mock(NodeClient::class.java)
+        val threadPool = mock(org.opensearch.threadpool.ThreadPool::class.java)
+        whenever(realClient.threadPool()).thenReturn(threadPool)
+        whenever(threadPool.threadContext).thenReturn(threadContext)
+
+        threadContext.putHeader("x-tenant-id", "tenant-secure")
+        threadContext.putHeader("_opendistro_security_user", "admin|role1")
+
+        val notificationInfo = EventSource("title", "ref_id", SeverityType.INFO, listOf())
+        val channelMessage = ChannelMessage("msg", null, null)
+        val listener: ActionListener<SendNotificationResponse> =
+            mock(ActionListener::class.java) as ActionListener<SendNotificationResponse>
+
+        var capturedTenantId: String? = null
+        var capturedSecurityHeader: String? = "not-null"
+        doAnswer {
+            capturedTenantId = threadContext.getHeader("x-tenant-id")
+            capturedSecurityHeader = threadContext.getHeader("_opendistro_security_user")
+            null
+        }.whenever(realClient).execute(any(ActionType::class.java), any(), any())
+
+        NotificationsPluginInterface.sendNotification(
+            realClient,
+            notificationInfo,
+            channelMessage,
+            listOf("channel-1"),
+            listener
+        )
+
+        // Tenant ID preserved
+        org.junit.jupiter.api.Assertions.assertEquals("tenant-secure", capturedTenantId)
+        // Security header stashed
+        org.junit.jupiter.api.Assertions.assertNull(capturedSecurityHeader)
+    }
+
     private fun mockGetNotificationConfigResponse(): GetNotificationConfigResponse {
         val sampleSlack = Slack("https://domain.com/sample_url#1234567890")
         val sampleConfig = NotificationConfig(

--- a/src/test/kotlin/org/opensearch/commons/utils/SecureClientWrapperTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/utils/SecureClientWrapperTests.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.opensearch.action.ActionType
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.util.concurrent.ThreadContext
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.threadpool.ThreadPool
+import org.opensearch.transport.client.Client
+
+internal class SecureClientWrapperTests {
+
+    private fun createMockClient(threadContext: ThreadContext): Client {
+        val client = mock(Client::class.java)
+        val threadPool = mock(ThreadPool::class.java)
+        `when`(client.threadPool()).thenReturn(threadPool)
+        `when`(threadPool.threadContext).thenReturn(threadContext)
+        return client
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `test tenant id header preserved across stash in execute`() {
+        val threadContext = ThreadContext(Settings.EMPTY)
+        val client = createMockClient(threadContext)
+        val wrapper = SecureClientWrapper(client)
+
+        threadContext.putHeader(SecureClientWrapper.TENANT_ID_HEADER, "tenant-123")
+
+        var capturedTenantId: String? = null
+        `when`(client.execute(any<ActionType<ActionResponse>>(), any(), any<ActionListener<ActionResponse>>())).thenAnswer {
+            capturedTenantId = threadContext.getHeader(SecureClientWrapper.TENANT_ID_HEADER)
+            null
+        }
+
+        wrapper.execute(
+            mock(ActionType::class.java) as ActionType<ActionResponse>,
+            mock(org.opensearch.action.ActionRequest::class.java),
+            mock(ActionListener::class.java) as ActionListener<ActionResponse>
+        )
+
+        assertEquals("tenant-123", capturedTenantId)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `test security context is still stashed`() {
+        val threadContext = ThreadContext(Settings.EMPTY)
+        val client = createMockClient(threadContext)
+        val wrapper = SecureClientWrapper(client)
+
+        threadContext.putHeader("_opendistro_security_user", "admin|backend_role")
+        threadContext.putHeader(SecureClientWrapper.TENANT_ID_HEADER, "tenant-abc")
+
+        var capturedSecurityHeader: String? = "not-null-sentinel"
+        var capturedTenantId: String? = null
+        `when`(client.execute(any<ActionType<ActionResponse>>(), any(), any<ActionListener<ActionResponse>>())).thenAnswer {
+            capturedSecurityHeader = threadContext.getHeader("_opendistro_security_user")
+            capturedTenantId = threadContext.getHeader(SecureClientWrapper.TENANT_ID_HEADER)
+            null
+        }
+
+        wrapper.execute(
+            mock(ActionType::class.java) as ActionType<ActionResponse>,
+            mock(org.opensearch.action.ActionRequest::class.java),
+            mock(ActionListener::class.java) as ActionListener<ActionResponse>
+        )
+
+        assertNull(capturedSecurityHeader)
+        assertEquals("tenant-abc", capturedTenantId)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `test no tenant id header does not inject null`() {
+        val threadContext = ThreadContext(Settings.EMPTY)
+        val client = createMockClient(threadContext)
+        val wrapper = SecureClientWrapper(client)
+
+        var capturedTenantId: String? = "sentinel"
+        `when`(client.execute(any<ActionType<ActionResponse>>(), any(), any<ActionListener<ActionResponse>>())).thenAnswer {
+            capturedTenantId = threadContext.getHeader(SecureClientWrapper.TENANT_ID_HEADER)
+            null
+        }
+
+        wrapper.execute(
+            mock(ActionType::class.java) as ActionType<ActionResponse>,
+            mock(org.opensearch.action.ActionRequest::class.java),
+            mock(ActionListener::class.java) as ActionListener<ActionResponse>
+        )
+
+        assertNull(capturedTenantId)
+    }
+}


### PR DESCRIPTION
Add stashAndPreserveTenant helper that reads the x-tenant-id header before stashing ThreadContext and re-injects it after, ensuring tenant context flows through to downstream transport actions like notifications.

