### PR TITLE
adding copied and reduced versions of SQL plugin classes needed for P…

### DIFF
--- a/src/main/java/org/opensearch/commons/ppl/PPLQueryAction.java
+++ b/src/main/java/org/opensearch/commons/ppl/PPLQueryAction.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.ppl;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * This is a copied, reduced version of SQL Plugin's PPLQueryAction
+ */
+public class PPLQueryAction extends ActionType<TransportPPLQueryResponse> {
+    public static final String NAME = "cluster:admin/opensearch/ppl";
+    public static final PPLQueryAction INSTANCE = new PPLQueryAction();
+
+    private PPLQueryAction() {
+        super(NAME, TransportPPLQueryResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/commons/ppl/TransportPPLQueryRequest.java
+++ b/src/main/java/org/opensearch/commons/ppl/TransportPPLQueryRequest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.ppl;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * This is a copied, reduced version of SQL Plugin's TransportPPLQueryRequest
+ */
+public class TransportPPLQueryRequest extends ActionRequest {
+
+    // Ordinals must match org.opensearch.sql.protocol.response.format.JsonResponseFormatter.Style
+    private enum Style {
+        COMPACT,
+        PRETTY
+    }
+
+    // actually used fields
+    private final String pplQuery;
+    private final String jsonContentString;
+    private final String path;
+
+    // fields put here to match the original TransportPPLQueryRequest
+    private final String format;
+    private final String explainMode;
+    private final boolean sanitize;
+    private final Style style;
+    private final boolean profile;
+    private final String queryId;
+
+    public TransportPPLQueryRequest(String pplQuery, String jsonContentString, String path) {
+        this.pplQuery = pplQuery;
+        this.jsonContentString = jsonContentString;
+        this.path = path;
+        this.format = "";
+        this.explainMode = null;
+        this.sanitize = true;
+        this.style = Style.COMPACT;
+        this.profile = false;
+        this.queryId = null;
+    }
+
+    public TransportPPLQueryRequest(StreamInput in) throws IOException {
+        super(in);
+        this.pplQuery = in.readOptionalString();
+        this.format = in.readOptionalString();
+        this.explainMode = in.readOptionalString();
+        this.jsonContentString = in.readOptionalString();
+        this.path = in.readOptionalString();
+        this.sanitize = in.readBoolean();
+        this.style = in.readEnum(Style.class);
+        this.profile = in.readBoolean();
+        this.queryId = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(pplQuery);
+        out.writeOptionalString(format);
+        out.writeOptionalString(explainMode);
+        out.writeOptionalString(jsonContentString);
+        out.writeOptionalString(path);
+        out.writeBoolean(sanitize);
+        out.writeEnum(style);
+        out.writeBoolean(profile);
+        out.writeOptionalString(queryId);
+    }
+
+    public String getPplQuery() {
+        return pplQuery;
+    }
+
+    public String getJsonContentString() {
+        return jsonContentString;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public String getExplainMode() {
+        return explainMode;
+    }
+
+    public boolean getSanitize() {
+        return sanitize;
+    }
+
+    public Style getStyle() {
+        return style;
+    }
+
+    public boolean getProfile() {
+        return profile;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/commons/ppl/TransportPPLQueryResponse.java
+++ b/src/main/java/org/opensearch/commons/ppl/TransportPPLQueryResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.ppl;
+
+import java.io.IOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+/**
+ * This is a copied, reduced version of SQL Plugin's TransportPPLQueryResponse
+ */
+public class TransportPPLQueryResponse extends ActionResponse {
+
+    private static final String CONTENT_TYPE = "application/json; charset=UTF-8";
+
+    private final String result;
+    private final String contentType;
+
+    public TransportPPLQueryResponse(String result) {
+        this.result = result;
+        this.contentType = CONTENT_TYPE;
+    }
+
+    public TransportPPLQueryResponse(StreamInput in) throws IOException {
+        super(in);
+        result = in.readString();
+        contentType = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        // super.writeTo(out) is a no-op, matching the SQL plugin's implementation
+        out.writeString(result);
+        out.writeString(CONTENT_TYPE);
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/WriteableTests.kt
@@ -37,6 +37,8 @@ import org.opensearch.commons.alerting.randomUserEmpty
 import org.opensearch.commons.alerting.randomWorkflow
 import org.opensearch.commons.alerting.util.IndexUtils
 import org.opensearch.commons.authuser.User
+import org.opensearch.commons.ppl.TransportPPLQueryRequest
+import org.opensearch.commons.ppl.TransportPPLQueryResponse
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.common.io.stream.Writeable
@@ -517,6 +519,58 @@ class WriteableTests {
         Assertions.assertEquals("content", newComment.content)
         Assertions.assertEquals(createdTime, newComment.createdTime)
         Assertions.assertEquals(user, newComment.user)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `test TransportPPLQueryRequest as stream`() {
+        val request = TransportPPLQueryRequest(
+            "source=my_index | where status='error'",
+            "{\"query\":\"source=my_index | where status='error'\"}",
+            "/_plugins/_ppl"
+        )
+
+        val out = BytesStreamOutput()
+        request.writeTo(out)
+
+        val streamIn = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newRequest = TransportPPLQueryRequest(streamIn)
+
+        Assertions.assertEquals(request.pplQuery, newRequest.pplQuery, "round-tripped PPL queries didn't match")
+        Assertions.assertEquals(request.jsonContentString, newRequest.jsonContentString, "round-tripped JSON content strings didn't match")
+        Assertions.assertEquals(request.path, newRequest.path, "round-tripped paths didn't match")
+
+        // dummy fields that are checked for completeness
+        Assertions.assertEquals(request.format, newRequest.format, "round-tripped formats didn't match")
+        Assertions.assertEquals(request.explainMode, newRequest.explainMode, "round-tripped explain modes didn't match")
+        Assertions.assertEquals(request.style, newRequest.style, "round-tripped styles didn't match")
+        Assertions.assertEquals(request.profile, newRequest.profile, "round-tripped profiles didn't match")
+        Assertions.assertEquals(request.queryId, newRequest.queryId, "round-tripped query IDs didn't match")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun `test TransportPPLQueryResponse as stream`() {
+        val response = TransportPPLQueryResponse(
+            "{\"schema\":[],\"datarows\":[],\"total\":0,\"size\":0}"
+        )
+
+        val out = BytesStreamOutput()
+        response.writeTo(out)
+
+        val streamIn = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val newResponse = TransportPPLQueryResponse(streamIn)
+
+        Assertions.assertEquals(
+            response.result,
+            newResponse.result,
+            "Round tripped results didn't match"
+        )
+        Assertions.assertEquals(
+            response.contentType,
+            newResponse.contentType,
+            "Round tripped content types didn't match"
+        )
     }
 
     fun randomDocumentLevelTriggerRunResult(): DocumentLevelTriggerRunResult {


### PR DESCRIPTION
### Description
This adds copied, reduced versions of SQL Plugin Request/Response classes to save Alerting plugin the need to depend on SQL plugin.

Original classes being copied:
- https://github.com/opensearch-project/sql/blob/main/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryRequest.java
- https://github.com/opensearch-project/sql/blob/main/plugin/src/main/java/org/opensearch/sql/plugin/transport/TransportPPLQueryResponse.java
- https://github.com/opensearch-project/sql/blob/main/plugin/src/main/java/org/opensearch/sql/plugin/transport/PPLQueryAction.java

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
