### PR TITLE
Feature/target arn field

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/Target.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/Target.kt
@@ -14,29 +14,34 @@ import java.io.IOException
  *
  * @property type the target type — LOCAL by default. Extensible for additional target types.
  * @property endpoint the URL of the remote target. Required when type is not LOCAL.
+ * @property arn the ARN of the remote resource. Required when type is not LOCAL.
  */
 data class Target(
     val type: String = LOCAL,
-    val endpoint: String = ""
+    val endpoint: String = "",
+    val arn: String = ""
 ) : Writeable, ToXContent {
 
     init {
         require(type.isNotBlank()) { "target type cannot be empty" }
         if (type != LOCAL) {
             require(endpoint.isNotBlank()) { "endpoint is required when target type is not LOCAL" }
+            require(arn.isNotBlank()) { "arn is required when target type is not LOCAL" }
         }
     }
 
     @Throws(IOException::class)
     constructor(sin: StreamInput) : this(
         type = sin.readString(),
-        endpoint = sin.readString()
+        endpoint = sin.readString(),
+        arn = sin.readString()
     )
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
             .field(TYPE_FIELD, type)
             .field(ENDPOINT_FIELD, endpoint)
+            .field(ARN_FIELD, arn)
         return builder.endObject()
     }
 
@@ -44,11 +49,13 @@ data class Target(
     override fun writeTo(out: StreamOutput) {
         out.writeString(type)
         out.writeString(endpoint)
+        out.writeString(arn)
     }
 
     companion object {
         const val TYPE_FIELD = "type"
         const val ENDPOINT_FIELD = "endpoint"
+        const val ARN_FIELD = "arn"
         const val LOCAL = "local"
         val DEFAULT = Target()
 
@@ -57,6 +64,7 @@ data class Target(
         fun parse(xcp: XContentParser): Target {
             var type = LOCAL
             var endpoint = ""
+            var arn = ""
 
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
             while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -65,9 +73,10 @@ data class Target(
                 when (fieldName) {
                     TYPE_FIELD -> type = xcp.text()
                     ENDPOINT_FIELD -> endpoint = xcp.text()
+                    ARN_FIELD -> arn = xcp.text()
                 }
             }
-            return Target(type, endpoint)
+            return Target(type, endpoint, arn)
         }
 
         @JvmStatic

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/TargetTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/TargetTests.kt
@@ -16,13 +16,15 @@ class TargetTests {
         val target = Target()
         assertEquals(Target.LOCAL, target.type)
         assertEquals("", target.endpoint)
+        assertEquals("", target.arn)
     }
 
     @Test
-    fun `test Target with custom type and endpoint`() {
-        val target = Target("custom_type", "https://example.com")
-        assertEquals("custom_type", target.type)
-        assertEquals("https://example.com", target.endpoint)
+    fun `test Target with custom type endpoint and arn`() {
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "arn:aws:es:us-west-2:123456789012:domain/my-domain")
+        assertEquals("AOS_DOMAIN", target.type)
+        assertEquals("https://my-domain.us-west-2.es.amazonaws.com", target.endpoint)
+        assertEquals("arn:aws:es:us-west-2:123456789012:domain/my-domain", target.arn)
     }
 
     @Test
@@ -35,13 +37,38 @@ class TargetTests {
     @Test
     fun `test Target requires endpoint for non-LOCAL type`() {
         assertThrows(IllegalArgumentException::class.java) {
-            Target("custom_type", "")
+            Target("AOS_DOMAIN", "", "arn:aws:es:us-west-2:123456789012:domain/my-domain")
         }
     }
 
     @Test
+    fun `test Target requires arn for non-LOCAL type`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "")
+        }
+    }
+
+    @Test
+    fun `test Target LOCAL type does not require arn`() {
+        val target = Target(Target.LOCAL, "", "")
+        assertEquals(Target.LOCAL, target.type)
+        assertEquals("", target.endpoint)
+        assertEquals("", target.arn)
+    }
+
+    @Test
     fun `test Target stream serialization roundtrip`() {
-        val target = Target("custom_type", "https://example.com")
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "arn:aws:es:us-west-2:123456789012:domain/my-domain")
+        val out = BytesStreamOutput()
+        target.writeTo(out)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        val deserialized = Target(sin)
+        assertEquals(target, deserialized)
+    }
+
+    @Test
+    fun `test Target stream serialization roundtrip LOCAL`() {
+        val target = Target()
         val out = BytesStreamOutput()
         target.writeTo(out)
         val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
@@ -51,7 +78,7 @@ class TargetTests {
 
     @Test
     fun `test Target XContent roundtrip`() {
-        val target = Target("custom_type", "https://example.com")
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-west-2.es.amazonaws.com", "arn:aws:es:us-west-2:123456789012:domain/my-domain")
         val builder = XContentFactory.jsonBuilder()
         target.toXContent(builder, ToXContent.EMPTY_PARAMS)
         val json = builder.toString()
@@ -60,5 +87,25 @@ class TargetTests {
         parser.nextToken()
         val parsed = Target.parse(parser)
         assertEquals(target, parsed)
+    }
+
+    @Test
+    fun `test Target XContent parse without arn field defaults to empty`() {
+        val json = """{"type":"local","endpoint":""}"""
+        val parser = XContentType.JSON.xContent().createParser(null, null, json)
+        parser.nextToken()
+        val parsed = Target.parse(parser)
+        assertEquals("local", parsed.type)
+        assertEquals("", parsed.endpoint)
+        assertEquals("", parsed.arn)
+    }
+
+    @Test
+    fun `test Target XContent includes arn field`() {
+        val target = Target("AOS_DOMAIN", "https://my-domain.us-east-1.es.amazonaws.com", "arn:aws:es:us-east-1:123456789012:domain/my-domain")
+        val builder = XContentFactory.jsonBuilder()
+        target.toXContent(builder, ToXContent.EMPTY_PARAMS)
+        val json = builder.toString()
+        assert(json.contains("\"arn\":\"arn:aws:es:us-east-1:123456789012:domain/my-domain\""))
     }
 }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -678,7 +678,7 @@ class XContentTests {
     @Test
     fun `test monitor with target parsing roundtrip`() {
         val monitor = randomQueryLevelMonitor().copy(
-            target = Target("custom_type", "https://example.com")
+            target = Target("custom_type", "https://example.com", "arn:aws:es:us-west-2:123456789012:domain/example")
         )
         val monitorString = monitor.toJsonStringWithUser()
         val parsedMonitor = Monitor.parse(parser(monitorString))
@@ -697,7 +697,7 @@ class XContentTests {
     @Test
     fun `test alert with target from monitor`() {
         val monitor = randomQueryLevelMonitor().copy(
-            target = Target("custom_type", "https://example.com")
+            target = Target("custom_type", "https://example.com", "arn:aws:es:us-west-2:123456789012:domain/example")
         )
         val alert = randomAlert(monitor)
         assertEquals("Alert should copy target from monitor", monitor.target, alert.target)
@@ -706,7 +706,7 @@ class XContentTests {
     @Test
     fun `test alert with target XContent roundtrip`() {
         val monitor = randomQueryLevelMonitor().copy(
-            target = Target("custom_type", "https://example.com")
+            target = Target("custom_type", "https://example.com", "arn:aws:es:us-west-2:123456789012:domain/example")
         )
         val alert = randomAlert(monitor)
         val alertString = alert.toXContent(builder(), ToXContent.EMPTY_PARAMS).string()
@@ -724,7 +724,7 @@ class XContentTests {
     @Test
     fun `test bucket-level monitor with target parsing roundtrip`() {
         val monitor = randomBucketLevelMonitor().copy(
-            target = Target("custom_type", "https://example.com")
+            target = Target("custom_type", "https://example.com", "arn:aws:es:us-west-2:123456789012:domain/example")
         )
         val monitorString = monitor.toJsonStringWithUser()
         val parsedMonitor = Monitor.parse(parser(monitorString))


### PR DESCRIPTION
Add arn field to Target data class to carry the ARN of the remote resources 
The ARN is parsed by the alerting plugin to extract account ID and resource ID for thread context header propagation.
