### PR TITLE
Cleanup SafeSerializationUtils to remove unused Guava classes

### DIFF
--- a/src/main/java/org/opensearch/commons/authuser/util/Base64Helper.java
+++ b/src/main/java/org/opensearch/commons/authuser/util/Base64Helper.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
@@ -79,6 +80,7 @@ public class Base64Helper {
     private final static class SafeObjectInputStream extends ObjectInputStream {
         public SafeObjectInputStream(InputStream in) throws IOException {
             super(in);
+            setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=10"));
         }
 
         @Override

--- a/src/main/java/org/opensearch/commons/authuser/util/SafeSerializationUtils.java
+++ b/src/main/java/org/opensearch/commons/authuser/util/SafeSerializationUtils.java
@@ -28,12 +28,7 @@ public final class SafeSerializationUtils {
     private static final Set<Class<?>> SAFE_ASSIGNABLE_FROM_CLASSES = Set
         .of(InetAddress.class, Number.class, Collection.class, Map.class, Enum.class);
 
-    private static final Set<String> SAFE_CLASS_NAMES = Set
-        .of(
-            "org.ldaptive.LdapAttribute$LdapAttributeValues",
-            "com.google.common.collect.ImmutableMap$SerializedForm",
-            "com.google.common.collect.ImmutableBiMap$SerializedForm"
-        );
+    private static final Set<String> SAFE_CLASS_NAMES = Set.of("org.ldaptive.LdapAttribute$LdapAttributeValues");
     static final Map<Class<?>, Boolean> safeClassCache = new ConcurrentHashMap<>();
 
     static boolean isSafeClass(Class<?> cls) {


### PR DESCRIPTION
### Description

In SafeSerializationUtils, we previously allowlisted Guava classes when user attribute serialization was enabled but now switched to wrapping in HashMap. These classes are no longer required and can be safely removed.

Also adds `ObjectInputFilter` with `maxdepth=10` to `SafeObjectInputStream` to limit deserialization depth.

Companion PR to https://github.com/opensearch-project/security/pull/6152

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
