### PR TITLE
Fix legacy webhook URI without httpcore5

### DIFF
--- a/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
+++ b/src/main/java/org/opensearch/commons/destination/message/LegacyBaseMessage.java
@@ -9,8 +9,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Map.Entry;
 
-import org.apache.hc.core5.net.URIBuilder;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -84,17 +84,26 @@ public abstract class LegacyBaseMessage implements Writeable {
                 if (Strings.isNullOrEmpty(scheme)) {
                     scheme = "https";
                 }
-                URIBuilder uriBuilder = new URIBuilder();
-                if (queryParams != null) {
-                    for (Map.Entry<String, String> e : queryParams.entrySet())
-                        uriBuilder.addParameter(e.getKey(), e.getValue());
-                }
-                return uriBuilder.setScheme(scheme).setHost(host).setPort(port).setPath(path).build();
+                return new URI(scheme, null, host, port, path, buildQueryString(queryParams), null);
             }
-            return new URIBuilder(endpoint).build();
+            return new URI(endpoint);
         } catch (URISyntaxException exception) {
             throw new IllegalStateException("Error creating URI");
         }
+    }
+
+    private static String buildQueryString(Map<String, String> queryParams) {
+        if (queryParams == null || queryParams.isEmpty()) {
+            return null;
+        }
+        StringBuilder query = new StringBuilder();
+        for (Entry<String, String> param : queryParams.entrySet()) {
+            if (query.length() > 0) {
+                query.append('&');
+            }
+            query.append(param.getKey()).append('=').append(param.getValue());
+        }
+        return query.toString();
     }
 
     @Override

--- a/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
+++ b/src/test/java/org/opensearch/commons/destination/message/LegacyCustomWebhookMessageTest.java
@@ -34,6 +34,32 @@ public class LegacyCustomWebhookMessageTest {
     }
 
     @Test
+    public void testGetUriWithFullUrl() {
+        LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withUrl("https://httpbin.org/post")
+            .build();
+
+        assertEquals("https://httpbin.org/post", message.getUri().toString());
+    }
+
+    @Test
+    public void testGetUriWithHostAndQueryParams() {
+        Map<String, String> queryParams = new HashMap<String, String>();
+        queryParams.put("token", "sometoken");
+        LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
+            .withMessage("Hello world")
+            .withHost("hooks.example.com")
+            .withPath("incoming")
+            .withQueryParams(queryParams)
+            .withPort(443)
+            .withScheme("https")
+            .build();
+
+        assertEquals("https://hooks.example.com:443/incoming?token=sometoken", message.getUri().toString());
+    }
+
+    @Test
     public void testRoundTrippingLegacyCustomWebhookMessageWithUrl() throws IOException {
         LegacyCustomWebhookMessage message = new LegacyCustomWebhookMessage.Builder("custom_webhook")
             .withMessage("Hello world")


### PR DESCRIPTION
## Summary
- Replace `org.apache.hc.core5.net.URIBuilder` with `java.net.URI` in `LegacyBaseMessage`
- Add unit tests for full-URL and host/query webhook URI construction

This fixes a `NoClassDefFoundError` when ISM publishes `custom_webhook`
error notifications. The index-management plugin bundles HttpClient 4, but
`LegacyBaseMessage` referenced HttpClient 5's `URIBuilder`, which crashed
the node via uncaught `Error` handling.

Fixes opensearch-project/OpenSearch#21601

## Test plan
- [x] `./gradlew test --tests "org.opensearch.commons.destination.message.LegacyCustomWebhookMessageTest"`



