### PR TITLE
Fix ScheduledJob.parse type overload broken by shared-parse refactor

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduledJob.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduledJob.kt
@@ -43,32 +43,6 @@ interface ScheduledJob : BaseModel {
          */
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, id: String = NO_ID, version: Long = NO_VERSION): ScheduledJob {
-            return parseWrapper(xcp, expectedType = null, id = id, version = version)
-        }
-
-        /**
-         * This function parses the job, but expects the type to be passed in. This is for the specific
-         * use case in sweeper where we first want to check if the job is allowed to be swept before
-         * trying to fully parse it. If you need to parse a job, you most likely want to use
-         * the above parse function.
-         */
-        @Throws(IOException::class)
-        fun parse(xcp: XContentParser, type: String, id: String = NO_ID, version: Long = NO_VERSION): ScheduledJob {
-            return parseWrapper(xcp, expectedType = type, id = id, version = version)
-        }
-
-        /**
-         * Shared implementation. Walks every top-level field of the outer object, dispatching
-         * to [XContentParser.namedObject] the first time we hit a known wrapper key
-         * ([SCHEDULED_JOB_WRAPPER_FIELDS]) and skipping everything else via [XContentParser.skipChildren].
-         * This is order-independent — security-injected fields like `all_shared_principals` may
-         * appear before or after the wrapper.
-         *
-         * When [expectedType] is non-null (the 2-arg overload's contract), a wrapper key must match
-         * it exactly; other wrapper keys are treated as ancillary data and skipped.
-         */
-        @Throws(IOException::class)
-        private fun parseWrapper(xcp: XContentParser, expectedType: String?, id: String, version: Long): ScheduledJob {
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
             var job: ScheduledJob? = null
             var token = xcp.nextToken()
@@ -76,9 +50,7 @@ interface ScheduledJob : BaseModel {
                 XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, xcp)
                 val fieldName = xcp.currentName()
                 xcp.nextToken() // advance to value
-                val isWrapper = fieldName in SCHEDULED_JOB_WRAPPER_FIELDS &&
-                    (expectedType == null || fieldName == expectedType)
-                if (isWrapper && job == null) {
+                if (fieldName in SCHEDULED_JOB_WRAPPER_FIELDS && job == null) {
                     XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
                     job = xcp.namedObject(ScheduledJob::class.java, fieldName, null)
                 } else {
@@ -88,6 +60,26 @@ interface ScheduledJob : BaseModel {
             }
             requireNotNull(job) { "No recognized ScheduledJob subtype wrapper found in document" }
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, token, xcp)
+            return job.fromDocument(id, version)
+        }
+
+        /**
+         * This function parses the job, but expects the type to be passed in. This is for the specific
+         * use case in sweeper where we first want to check if the job is allowed to be swept before
+         * trying to fully parse it. If you need to parse a job, you most likely want to use
+         * the above parse function.
+         *
+         * The sweeper detects the type by scanning the outer object first, so by the time it calls
+         * this overload the parser is already positioned ON the wrapper's [XContentParser.Token.FIELD_NAME]
+         * (having consumed the outer START_OBJECT and any leading ancillary fields). We therefore parse
+         * the already-located wrapper directly rather than re-walking the outer object.
+         */
+        @Throws(IOException::class)
+        fun parse(xcp: XContentParser, type: String, id: String = NO_ID, version: Long = NO_VERSION): ScheduledJob {
+            // Parser is on the wrapper field name (e.g. "monitor"); advance to its value object.
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.currentToken(), xcp)
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+            val job = xcp.namedObject(ScheduledJob::class.java, type, null)
             return job.fromDocument(id, version)
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -4,7 +4,10 @@ import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.builder
 import org.opensearch.commons.alerting.model.action.Action
@@ -38,8 +41,12 @@ import org.opensearch.commons.alerting.toJsonStringWithUser
 import org.opensearch.commons.alerting.util.string
 import org.opensearch.commons.authuser.User
 import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.SearchModule
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
@@ -225,6 +232,56 @@ class XContentTests {
         val monitorString = workflow.toJsonStringWithUser()
         val parsedMonitor = Workflow.parse(parser(monitorString))
         Assertions.assertEquals(workflow, parsedMonitor, "Round tripping BucketLevelMonitor doesn't work")
+    }
+
+    @Test
+    fun `test ScheduledJob parse round-trips a type-wrapped monitor`() {
+        val monitor = randomQueryLevelMonitor()
+        val parsed = ScheduledJob.parse(scheduledJobParser(monitor.toWrappedJsonString()))
+        assertEquals("Round tripping monitor through ScheduledJob.parse doesn't work", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse round-trips a type-wrapped workflow`() {
+        val workflow = randomWorkflow()
+        val parsed = ScheduledJob.parse(scheduledJobParser(workflow.toWrappedJsonString()))
+        assertEquals("Round tripping workflow through ScheduledJob.parse doesn't work", workflow, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse tolerates ancillary field before the wrapper`() {
+        val monitor = randomQueryLevelMonitor()
+        // Simulate a security-injected DLS field (e.g. all_shared_principals) preceding the wrapper.
+        val jobString = """{"all_shared_principals":["u1","u2"],""" +
+            monitor.toWrappedJsonString().removePrefix("{")
+        val parsed = ScheduledJob.parse(scheduledJobParser(jobString))
+        assertEquals("Leading ancillary field should be skipped", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse tolerates ancillary field after the wrapper`() {
+        val monitor = randomQueryLevelMonitor()
+        // Injected field trailing the wrapper.
+        val jobString = monitor.toWrappedJsonString().removeSuffix("}") +
+            ""","all_shared_principals":["u1","u2"]}"""
+        val parsed = ScheduledJob.parse(scheduledJobParser(jobString))
+        assertEquals("Trailing ancillary field should be skipped", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob type overload parses when positioned at the wrapper field name`() {
+        // Mirrors JobSweeper: detect the type by scanning the outer object (which leaves the parser
+        // positioned ON the wrapper's FIELD_NAME), then parse with the type overload.
+        val monitor = randomQueryLevelMonitor()
+        val jobString = """{"all_shared_principals":["u1"],""" +
+            monitor.toWrappedJsonString().removePrefix("{")
+        val xcp = scheduledJobParser(jobString)
+        val type = advanceToWrapperFieldName(xcp)
+        assertEquals("monitor", type)
+        // Pass id/version explicitly (as JobSweeper does) to bind the type overload — the 2-arg form
+        // is ambiguous with parse(xcp, id) and would resolve to the no-type overload.
+        val parsed = ScheduledJob.parse(xcp, type, monitor.id, monitor.version)
+        assertEquals("Sweeper-style parse (detect type, then parse) doesn't work", monitor, parsed)
     }
 
     @Test
@@ -737,5 +794,57 @@ class XContentTests {
         val monitorString = monitor.toJsonStringWithUser()
         val parsedMonitor = Monitor.parse(parser(monitorString))
         assertEquals("Default target should be null", null, parsedMonitor.target)
+    }
+
+    /**
+     * Serializes as a stored scheduled-job doc would be: user preserved and wrapped in the type
+     * object (`{"monitor":{...}}`), matching what the transport layer writes to the config index.
+     */
+    private fun Monitor.toWrappedJsonString(): String =
+        toXContentWithUser(builder(), ToXContent.MapParams(mapOf("with_type" to "true"))).string()
+
+    private fun Workflow.toWrappedJsonString(): String =
+        toXContentWithUser(builder(), ToXContent.MapParams(mapOf("with_type" to "true"))).string()
+
+    /**
+     * Builds a parser whose registry knows the [ScheduledJob] subtypes (monitor, workflow) so
+     * [ScheduledJob.parse]'s `namedObject` dispatch resolves. Positioned before the outer START_OBJECT,
+     * matching how [org.opensearch.commons.alerting.model.ScheduledJob.parse] expects to be called.
+     */
+    private fun scheduledJobParser(xc: String): XContentParser {
+        val entries = listOf(
+            Monitor.XCONTENT_REGISTRY,
+            Workflow.XCONTENT_REGISTRY,
+            SearchInput.XCONTENT_REGISTRY,
+            DocLevelMonitorInput.XCONTENT_REGISTRY,
+            QueryLevelTrigger.XCONTENT_REGISTRY,
+            BucketLevelTrigger.XCONTENT_REGISTRY,
+            DocumentLevelTrigger.XCONTENT_REGISTRY,
+            ChainedAlertTrigger.XCONTENT_REGISTRY
+        ) + SearchModule(Settings.EMPTY, emptyList()).namedXContents
+        val registry = NamedXContentRegistry(entries)
+        return XContentType.JSON.xContent().createParser(registry, LoggingDeprecationHandler.INSTANCE, xc)
+    }
+
+    /**
+     * Mirrors JobSweeper.isSweepableJobType: consumes the outer START_OBJECT and advances past any
+     * leading non-wrapper fields, leaving the parser positioned ON the wrapper's FIELD_NAME. Returns
+     * the detected wrapper type.
+     */
+    private fun advanceToWrapperFieldName(xcp: XContentParser): String {
+        val wrappers = setOf("monitor", "workflow")
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+        var token = xcp.nextToken()
+        while (token != null && token != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME && xcp.currentName() in wrappers) {
+                return xcp.currentName()
+            }
+            if (token == XContentParser.Token.FIELD_NAME) {
+                xcp.nextToken()
+                xcp.skipChildren()
+            }
+            token = xcp.nextToken()
+        }
+        throw AssertionError("No wrapper field found")
     }
 }


### PR DESCRIPTION
### Description

PR #981 unified the two `ScheduledJob.parse` overloads behind a single top-level field walk. However, the two overloads are invoked with the parser at **different positions**:

- `parse(xcp, id, version)` — parser is positioned *before* the outer `START_OBJECT`.
- `parse(xcp, type, id, version)` — the sweeper's `JobSweeper.isSweepableJobType()` has *already* consumed the outer `START_OBJECT` and advanced the parser to the wrapper's `FIELD_NAME` (e.g. `"monitor"`).

The unified walk assumed the first position for both. On the sweeper path it therefore descended *into* the monitor object, found no wrapper key, and threw — surfacing as `Unable to parse ScheduledJob source` in alerting logs. Because the job failed to parse, it was never scheduled, and the `postIndex`/`postDelete` shard-listener callbacks that drive `AlertMover.moveAlerts` never fired. This broke a range of alerting integration tests (delete-trigger alert movement, workflow scheduling, doc-level monitor execution, monitor stats scheduling).

### Fix

- Restore the `type` overload to parse the already-located wrapper directly (matching its original, pre-#981 contract).
- Keep the no-type overload order-independent so security-injected top-level fields (e.g. `all_shared_principals` from the resource-sharing framework's DLS) are still tolerated before or after the wrapper.
- Add `XContentTests` covering both parser positions and leading/trailing ancillary fields. `ScheduledJob.parse` previously had no direct test coverage, which is how the regression slipped through.

### Related

- Regressed by #981
- Unblocks opensearch-project/alerting#2180

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.