### PR TITLE
Fix CVE-2026-45292: Force opentelemetry-api to >=1.62.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ configurations {
             force "org.bouncycastle:bcpg-jdk18on:1.84"
             force "org.bouncycastle:bcprov-jdk18on:1.84"
             force "org.bouncycastle:bcutil-jdk18on:1.84"
+            force "io.opentelemetry:opentelemetry-api:1.62.0"
+            force "io.opentelemetry:opentelemetry-context:1.62.0"
         }
     }
     ktlint {


### PR DESCRIPTION
The opentelemetry-java baggage propagation implementation prior to 1.62.0 is vulnerable to unbounded memory allocation and CPU consumption when parsing oversized baggage (CVE-2026-45292, CVSS 5.3).

opentelemetry-api is a transitive dependency pulled via org.opensearch.test:framework from OpenSearch core. OpenSearch core already bumped to 1.62.0 (PR #21595) and 1.63.0 (PR #22111), but the advisory scanner still flags common-utils because its resolved dependency tree shows the older version.

Add resolutionStrategy.force for opentelemetry-api and opentelemetry-context to pin the patched version

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/common-utils/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
