### PR TITLE
[Backport 3.8] Order-independent ScheduledJob.parse tolerating ancillary top-level fields (#984)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduledJob.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/model/ScheduledJob.kt
@@ -23,21 +23,43 @@ interface ScheduledJob : BaseModel {
 
         private val XCONTENT_WITH_TYPE = ToXContent.MapParams(mapOf("with_type" to "true"))
 
+        // Field names that are registered ScheduledJob subtypes and therefore dispatch to the
+        // corresponding parser via [XContentParser.namedObject]. Anything else at the top level
+        // of a stored doc is treated as ancillary data (for example `all_shared_principals`
+        // injected by the security plugin's resource-sharing framework for DLS) and skipped.
+        private val SCHEDULED_JOB_WRAPPER_FIELDS = setOf("monitor", "workflow")
+
         /**
-         * This function parses the job, delegating to the specific subtype parser registered in the [XContentParser.getXContentRegistry]
-         * at runtime.  Each concrete job subclass is expected to register a parser in this registry.
-         * The Job's json representation is expected to be of the form:
+         * This function parses the job, delegating to the specific subtype parser registered in
+         * the [XContentParser.getXContentRegistry] at runtime. Each concrete job subclass is
+         * expected to register a parser in this registry. The Job's JSON representation is
+         * expected to be of the form:
          *     { "<job_type>" : { <job fields> } }
+         * Any additional top-level fields (for example `all_shared_principals` injected by the
+         * security plugin's resource-sharing framework) are tolerated and skipped, regardless of
+         * whether they appear before or after the wrapper.
          *
-         * If the job comes from an OpenSearch index it's [id] and [version] can also be supplied.
+         * If the job comes from an OpenSearch index its [id] and [version] can also be supplied.
          */
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, id: String = NO_ID, version: Long = NO_VERSION): ScheduledJob {
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp)
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
-            val job = xcp.namedObject(ScheduledJob::class.java, xcp.currentName(), null)
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp)
+            var job: ScheduledJob? = null
+            var token = xcp.nextToken()
+            while (token != null && token != XContentParser.Token.END_OBJECT) {
+                XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, xcp)
+                val fieldName = xcp.currentName()
+                xcp.nextToken() // advance to value
+                if (fieldName in SCHEDULED_JOB_WRAPPER_FIELDS && job == null) {
+                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp)
+                    job = xcp.namedObject(ScheduledJob::class.java, fieldName, null)
+                } else {
+                    xcp.skipChildren()
+                }
+                token = xcp.nextToken()
+            }
+            requireNotNull(job) { "No recognized ScheduledJob subtype wrapper found in document" }
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, token, xcp)
             return job.fromDocument(id, version)
         }
 
@@ -46,12 +68,18 @@ interface ScheduledJob : BaseModel {
          * use case in sweeper where we first want to check if the job is allowed to be swept before
          * trying to fully parse it. If you need to parse a job, you most likely want to use
          * the above parse function.
+         *
+         * The sweeper detects the type by scanning the outer object first, so by the time it calls
+         * this overload the parser is already positioned ON the wrapper's [XContentParser.Token.FIELD_NAME]
+         * (having consumed the outer START_OBJECT and any leading ancillary fields). We therefore parse
+         * the already-located wrapper directly rather than re-walking the outer object.
          */
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, type: String, id: String = NO_ID, version: Long = NO_VERSION): ScheduledJob {
+            // Parser is on the wrapper field name (e.g. "monitor"); advance to its value object.
+            XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.currentToken(), xcp)
             XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
             val job = xcp.namedObject(ScheduledJob::class.java, type, null)
-            XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp)
             return job.fromDocument(id, version)
         }
     }

--- a/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/alerting/model/XContentTests.kt
@@ -4,7 +4,10 @@ import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.opensearch.common.io.stream.BytesStreamOutput
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentFactory
+import org.opensearch.common.xcontent.XContentType
 import org.opensearch.common.xcontent.json.JsonXContent
 import org.opensearch.commons.alerting.builder
 import org.opensearch.commons.alerting.model.action.Action
@@ -38,8 +41,12 @@ import org.opensearch.commons.alerting.toJsonStringWithUser
 import org.opensearch.commons.alerting.util.string
 import org.opensearch.commons.authuser.User
 import org.opensearch.core.common.io.stream.StreamInput
+import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.core.xcontent.XContentParser
+import org.opensearch.core.xcontent.XContentParserUtils
 import org.opensearch.index.query.QueryBuilders
+import org.opensearch.search.SearchModule
 import org.opensearch.search.builder.SearchSourceBuilder
 import org.opensearch.test.OpenSearchTestCase
 import java.time.Instant
@@ -737,5 +744,107 @@ class XContentTests {
         val monitorString = monitor.toJsonStringWithUser()
         val parsedMonitor = Monitor.parse(parser(monitorString))
         assertEquals("Default target should be null", null, parsedMonitor.target)
+    }
+
+    @Test
+    fun `test ScheduledJob parse round-trips a type-wrapped monitor`() {
+        val monitor = randomQueryLevelMonitor()
+        val parsed = ScheduledJob.parse(scheduledJobParser(monitor.toWrappedJsonString()))
+        assertEquals("Round tripping monitor through ScheduledJob.parse doesn't work", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse round-trips a type-wrapped workflow`() {
+        val workflow = randomWorkflow()
+        val parsed = ScheduledJob.parse(scheduledJobParser(workflow.toWrappedJsonString()))
+        assertEquals("Round tripping workflow through ScheduledJob.parse doesn't work", workflow, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse tolerates ancillary field before the wrapper`() {
+        val monitor = randomQueryLevelMonitor()
+        // Simulate a security-injected DLS field (e.g. all_shared_principals) preceding the wrapper.
+        val jobString = """{"all_shared_principals":["u1","u2"],""" +
+            monitor.toWrappedJsonString().removePrefix("{")
+        val parsed = ScheduledJob.parse(scheduledJobParser(jobString))
+        assertEquals("Leading ancillary field should be skipped", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob parse tolerates ancillary field after the wrapper`() {
+        val monitor = randomQueryLevelMonitor()
+        // Injected field trailing the wrapper.
+        val jobString = monitor.toWrappedJsonString().removeSuffix("}") +
+            ""","all_shared_principals":["u1","u2"]}"""
+        val parsed = ScheduledJob.parse(scheduledJobParser(jobString))
+        assertEquals("Trailing ancillary field should be skipped", monitor, parsed)
+    }
+
+    @Test
+    fun `test ScheduledJob type overload parses when positioned at the wrapper field name`() {
+        // Mirrors JobSweeper: detect the type by scanning the outer object (which leaves the parser
+        // positioned ON the wrapper's FIELD_NAME), then parse with the type overload.
+        val monitor = randomQueryLevelMonitor()
+        val jobString = """{"all_shared_principals":["u1"],""" +
+            monitor.toWrappedJsonString().removePrefix("{")
+        val xcp = scheduledJobParser(jobString)
+        val type = advanceToWrapperFieldName(xcp)
+        assertEquals("monitor", type)
+        // Pass id/version explicitly (as JobSweeper does) to bind the type overload — the 2-arg form
+        // is ambiguous with parse(xcp, id) and would resolve to the no-type overload.
+        val parsed = ScheduledJob.parse(xcp, type, monitor.id, monitor.version)
+        assertEquals("Sweeper-style parse (detect type, then parse) doesn't work", monitor, parsed)
+    }
+
+    /**
+     * Serializes as a stored scheduled-job doc would be: user preserved and wrapped in the type
+     * object (`{"monitor":{...}}`), matching what the transport layer writes to the config index.
+     */
+    private fun Monitor.toWrappedJsonString(): String =
+        toXContentWithUser(builder(), ToXContent.MapParams(mapOf("with_type" to "true"))).string()
+
+    private fun Workflow.toWrappedJsonString(): String =
+        toXContentWithUser(builder(), ToXContent.MapParams(mapOf("with_type" to "true"))).string()
+
+    /**
+     * Builds a parser whose registry knows the [ScheduledJob] subtypes (monitor, workflow) so
+     * [ScheduledJob.parse]'s `namedObject` dispatch resolves. Positioned before the outer START_OBJECT,
+     * matching how [org.opensearch.commons.alerting.model.ScheduledJob.parse] expects to be called.
+     */
+    private fun scheduledJobParser(xc: String): XContentParser {
+        val entries = listOf(
+            Monitor.XCONTENT_REGISTRY,
+            Workflow.XCONTENT_REGISTRY,
+            SearchInput.XCONTENT_REGISTRY,
+            DocLevelMonitorInput.XCONTENT_REGISTRY,
+            QueryLevelTrigger.XCONTENT_REGISTRY,
+            BucketLevelTrigger.XCONTENT_REGISTRY,
+            DocumentLevelTrigger.XCONTENT_REGISTRY,
+            ChainedAlertTrigger.XCONTENT_REGISTRY
+        ) + SearchModule(Settings.EMPTY, emptyList()).namedXContents
+        val registry = NamedXContentRegistry(entries)
+        return XContentType.JSON.xContent().createParser(registry, LoggingDeprecationHandler.INSTANCE, xc)
+    }
+
+    /**
+     * Mirrors JobSweeper.isSweepableJobType: consumes the outer START_OBJECT and advances past any
+     * leading non-wrapper fields, leaving the parser positioned ON the wrapper's FIELD_NAME. Returns
+     * the detected wrapper type.
+     */
+    private fun advanceToWrapperFieldName(xcp: XContentParser): String {
+        val wrappers = setOf("monitor", "workflow")
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp)
+        var token = xcp.nextToken()
+        while (token != null && token != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME && xcp.currentName() in wrappers) {
+                return xcp.currentName()
+            }
+            if (token == XContentParser.Token.FIELD_NAME) {
+                xcp.nextToken()
+                xcp.skipChildren()
+            }
+            token = xcp.nextToken()
+        }
+        throw AssertionError("No wrapper field found")
     }
 }


### PR DESCRIPTION
### Description

Backports #984 (order-independent `ScheduledJob.parse` that tolerates ancillary top-level fields) to the `3.8` release branch.

The `3.8` parse asserts `END_OBJECT` immediately after the type wrapper. When a stored scheduled-job doc carries an extra top-level field — e.g. the security plugin's `all_shared_principals` DLS field, injected once alerting onboards to the Resource-Sharing Framework — the transport GET/update parse path fails with:

```
ParsingException: expecting token of type [END_OBJECT] but found [FIELD_NAME]
```

surfacing as a `500` on monitor GET/PUT. #984 fixed this on `main` but was never backported, so consumers building against the published `3.8.0.0-SNAPSHOT` (including the alerting RSC-onboarding PR's CI) still hit the strict parser.

### Changes

- `ScheduledJob.kt` — **byte-identical to `main`** after #984. The no-type overload walks top-level fields order-independently, dispatching the recognized wrapper (`monitor`/`workflow`) via `namedObject` and skipping any ancillary field before or after it. The type overload (used by `JobSweeper`, which pre-positions the parser on the wrapper `FIELD_NAME`) parses the located wrapper directly.
- `XContentTests.kt` — ports #984's regression tests: type-wrapped monitor/workflow round-trips, tolerance of an ancillary field before **and** after the wrapper (the exact CI failure), and sweeper-style type-overload parse.

### Testing

- `./gradlew compileTestKotlin` — passes
- `./gradlew test --tests XContentTests` — all pass, including the 5 new `ScheduledJob.parse` cases

### Check List
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
