### PR TITLE
[Backport 3.8] Override DocRequest.type() on alerting request classes (#981)

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeAlertRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeAlertRequest.kt
@@ -10,6 +10,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import java.io.IOException
@@ -54,5 +55,9 @@ class AcknowledgeAlertRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return monitorId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeChainedAlertRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/AcknowledgeChainedAlertRequest.kt
@@ -9,6 +9,7 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import java.io.IOException
@@ -49,5 +50,9 @@ class AcknowledgeChainedAlertRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return workflowId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteMonitorRequest.kt
@@ -5,6 +5,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.action.support.WriteRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import java.io.IOException
@@ -41,5 +42,9 @@ class DeleteMonitorRequest : DocRequest, ActionRequest {
 
     override fun id(): String? {
         return monitorId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DeleteWorkflowRequest.kt
@@ -4,6 +4,7 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import java.io.IOException
@@ -45,5 +46,9 @@ class DeleteWorkflowRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return workflowId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.WORKFLOW_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/DocLevelMonitorFanOutRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/DocLevelMonitorFanOutRequest.kt
@@ -13,6 +13,7 @@ import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.MonitorMetadata
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.WorkflowRunContext
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.core.index.shard.ShardId
@@ -107,5 +108,9 @@ class DocLevelMonitorFanOutRequest : ActionRequest, DocRequest, ToXContentObject
 
     override fun id(): String? {
         return monitor.id
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetAlertsRequest.kt
@@ -5,6 +5,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Table
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.index.query.BoolQueryBuilder
@@ -86,5 +87,9 @@ class GetAlertsRequest : ActionRequest, DocRequest {
         // Access is gated on the underlying monitor when a single monitorId is provided; otherwise let the security
         // plugin fall back to search-level DLS filtering.
         return monitorId ?: monitorIds?.singleOrNull()
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetFindingsRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetFindingsRequest.kt
@@ -5,6 +5,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Table
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.index.query.BoolQueryBuilder
@@ -65,5 +66,9 @@ class GetFindingsRequest : ActionRequest, DocRequest {
         // Access is gated on the underlying monitor when a single monitorId is provided; otherwise fall back to
         // search-level DLS filtering.
         return monitorId ?: monitorIds?.singleOrNull()
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetMonitorRequest.kt
@@ -9,6 +9,7 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.rest.RestRequest
@@ -64,5 +65,9 @@ class GetMonitorRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return monitorId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowAlertsRequest.kt
@@ -5,6 +5,7 @@ import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Table
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import java.io.IOException
@@ -79,5 +80,9 @@ class GetWorkflowAlertsRequest : ActionRequest, DocRequest {
     override fun id(): String? {
         // Access is gated on the workflow when a single workflowId is provided; otherwise fall back to search-level DLS.
         return workflowIds?.singleOrNull()
+    }
+
+    override fun type(): String {
+        return AlertingConstants.WORKFLOW_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/GetWorkflowRequest.kt
@@ -9,6 +9,7 @@ import org.opensearch.action.ActionRequest
 import org.opensearch.action.ActionRequestValidationException
 import org.opensearch.action.DocRequest
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.rest.RestRequest
@@ -48,5 +49,9 @@ class GetWorkflowRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return workflowId
+    }
+
+    override fun type(): String {
+        return AlertingConstants.WORKFLOW_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexMonitorRequest.kt
@@ -7,6 +7,7 @@ import org.opensearch.action.support.WriteRequest
 import org.opensearch.commons.alerting.model.DocLevelMonitorInput
 import org.opensearch.commons.alerting.model.Monitor
 import org.opensearch.commons.alerting.model.ScheduledJob
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.commons.alerting.util.IndexPatternUtils
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
@@ -91,5 +92,9 @@ class IndexMonitorRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return monitor.id
+    }
+
+    override fun type(): String {
+        return AlertingConstants.MONITOR_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/action/IndexWorkflowRequest.kt
@@ -8,6 +8,7 @@ import org.opensearch.action.support.WriteRequest
 import org.opensearch.commons.alerting.model.CompositeInput
 import org.opensearch.commons.alerting.model.ScheduledJob
 import org.opensearch.commons.alerting.model.Workflow
+import org.opensearch.commons.alerting.util.AlertingConstants
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
 import org.opensearch.rest.RestRequest
@@ -171,5 +172,9 @@ class IndexWorkflowRequest : ActionRequest, DocRequest {
 
     override fun id(): String? {
         return workflow.id
+    }
+
+    override fun type(): String {
+        return AlertingConstants.WORKFLOW_RESOURCE_TYPE
     }
 }

--- a/src/main/kotlin/org/opensearch/commons/alerting/util/AlertingConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/AlertingConstants.kt
@@ -5,5 +5,16 @@ class AlertingConstants {
         const val ALL_ALERT_INDEX_PATTERN = ".opendistro-alerting-alert*"
 
         const val ALL_COMMENTS_INDEX_PATTERN = ".opensearch-alerting-comments*"
+
+        /** Resource type registered with the security plugin's resource-sharing framework for monitors. */
+        const val MONITOR_RESOURCE_TYPE = "monitor"
+
+        /**
+         * Resource type registered with the security plugin's resource-sharing framework for workflows.
+         * The value is "alerting-workflow" (not "workflow") to avoid colliding with the "workflow"
+         * resource type registered by flow-framework. Alerting registers the same value on its
+         * [org.opensearch.security.spi.resources.ResourceProvider], so this constant must match.
+         */
+        const val WORKFLOW_RESOURCE_TYPE = "alerting-workflow"
     }
 }


### PR DESCRIPTION
### Description

Backports #981 (the `DocRequest.type()` overrides on alerting request classes) to the `3.8` release branch. This is the companion to #998, which backported only the `ScheduledJob.parse` half of #981/#984. The `type()` overrides did **not** make it into #998's squash-merge, so `3.8` currently has the parse fix but not the RSC-gating fix.

### Why this is needed

The security plugin's `ResourceAccessEvaluator.shouldEvaluate(...)` gates a request only when `DocRequest.type()` matches one of the configured `protected_types`. The `DocRequest.type()` **default returns `"indices"`**, so without an override the evaluator skips every alerting request and the resource-sharing ActionFilter grants access unconditionally — a legacy-authz bypass under RSC.

Concretely, on a `3.8`-based build with RSC enabled, a monitor `GET`/`DELETE`/`UPDATE` by a non-owner (or before migration) is **not** gated and returns `200` instead of `403`. This was caught by alerting's `SecureResourceSharingMonitorRestApiIT` (e.g. `test bob cannot get alice's monitor without share`) and `RscMigrateE2ERestApiIT` failing on the alerting RSC-onboarding PR.

### Changes

Overrides `type()` on every alerting `DocRequest` targeting the shared resource index (`SCHEDULED_JOBS_INDEX`): `AcknowledgeAlert`, `AcknowledgeChainedAlert`, `DeleteMonitor`, `DeleteWorkflow`, `DocLevelMonitorFanOut`, `GetAlerts`, `GetFindings`, `GetMonitor`, `GetWorkflowAlerts`, `GetWorkflow`, `IndexMonitor`, `IndexWorkflow`. Adds `MONITOR_RESOURCE_TYPE` / `WORKFLOW_RESOURCE_TYPE` constants in `AlertingConstants` as the single source of truth. Comment requests are intentionally excluded — comments are not a registered resource type.

**Departure from `main`:** `WORKFLOW_RESOURCE_TYPE` is `"alerting-workflow"` (not `"workflow"`). This matches the value alerting registers on its `ResourceProvider.resourceType` — renamed alerting-side to avoid colliding with the `"workflow"` resource type registered by flow-framework. `main` still says `"workflow"`, which prevents the evaluator from gating workflow requests end-to-end; a companion `main`-side fix should follow.

### Testing

- `./gradlew compileKotlin compileTestKotlin` — passes
- Verified end-to-end against a local alerting build (mavenLocal snapshot with this change): `SecureResourceSharingMonitorRestApiIT` (31 tests, 3 skipped, 0 failures) and `RscMigrateE2ERestApiIT` both pass; without this change both fail with `200`-instead-of-`403`.

### Check List
- [x] New functionality includes testing. (Behavior is exercised by the consuming alerting RSC integ suites; these request classes have no independent unit assertions for `type()` on `main` either.)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
