### PR TITLE
Align WORKFLOW_RESOURCE_TYPE with alerting's registered resource type

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/alerting/util/AlertingConstants.kt
+++ b/src/main/kotlin/org/opensearch/commons/alerting/util/AlertingConstants.kt
@@ -9,7 +9,13 @@ class AlertingConstants {
         /** Resource type registered with the security plugin's resource-sharing framework for monitors. */
         const val MONITOR_RESOURCE_TYPE = "monitor"
 
-        /** Resource type registered with the security plugin's resource-sharing framework for workflows. */
-        const val WORKFLOW_RESOURCE_TYPE = "workflow"
+        /**
+         * Resource type registered with the security plugin's resource-sharing framework for workflows.
+         * The value is "alerting-workflow" (not "workflow") to avoid colliding with the "workflow"
+         * resource type registered by flow-framework. Alerting registers the same value on its
+         * ResourceProvider, so this constant must match or the ResourceAccessEvaluator will not gate
+         * workflow requests (their DocRequest.type() would report a type no provider owns).
+         */
+        const val WORKFLOW_RESOURCE_TYPE = "alerting-workflow"
     }
 }


### PR DESCRIPTION
### Description

The workflow request classes (`GetWorkflowRequest`, `GetWorkflowAlertsRequest`, `DeleteWorkflowRequest`, `IndexWorkflowRequest`) return `AlertingConstants.WORKFLOW_RESOURCE_TYPE` from `DocRequest.type()`. The security plugin's `ResourceAccessEvaluator.shouldEvaluate` gates a request only when `type()` matches one of the registered protected resource types.

Alerting registers its workflow `ResourceProvider` as `"alerting-workflow"` — renamed to avoid colliding with the `"workflow"` resource type that flow-framework registers. But this constant was still `"workflow"`, so under the resource-sharing framework the workflow requests reported a type no provider owns and the evaluator skipped gating them (workflow GET/DELETE/UPDATE fell through to legacy authz).

Sets the constant to `"alerting-workflow"` to match the registered `ResourceProvider`.

### Related

- The 3.8 backport already carries this value: https://github.com/opensearch-project/common-utils/pull/1000
- Alerting registers the matching type in its `ResourceProvider`: https://github.com/opensearch-project/alerting/pull/2180

### Testing

- `./gradlew compileKotlin compileTestKotlin` — passes. No test pins the literal value.
- Behavior is exercised end-to-end by the alerting RSC integ suites building against the snapshot.

### Check List
- [x] New functionality includes testing. (Covered by the consuming alerting RSC suites; no unit test pins this constant on `main` either.)
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
