### PR TITLE
Support keystore references for notification URLs

### DIFF
--- a/src/main/kotlin/org/opensearch/commons/notifications/NotificationConfigReference.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/NotificationConfigReference.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.notifications
+
+import org.opensearch.commons.utils.validateUrl
+
+private const val KEYSTORE_REFERENCE_PREFIX = "\${keystore:"
+private val KEYSTORE_REFERENCE_PATTERN = Regex("\\$\\{keystore:([A-Za-z0-9_.-]+)}")
+
+/**
+ * Returns whether [value] is a complete reference to an OpenSearch keystore setting alias.
+ */
+fun isKeystoreReference(value: String): Boolean = KEYSTORE_REFERENCE_PATTERN.matches(value)
+
+/**
+ * Validates a notification URL or a complete OpenSearch keystore reference.
+ */
+fun validateUrlOrKeystoreReference(value: String) {
+    if (value.contains(KEYSTORE_REFERENCE_PREFIX)) {
+        require(isKeystoreReference(value)) { "Invalid OpenSearch keystore reference" }
+    } else {
+        validateUrl(value)
+    }
+}

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Chime.kt
@@ -5,8 +5,8 @@
 package org.opensearch.commons.notifications.model
 
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
+import org.opensearch.commons.notifications.validateUrlOrKeystoreReference
 import org.opensearch.commons.utils.logger
-import org.opensearch.commons.utils.validateUrl
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
@@ -26,7 +26,7 @@ data class Chime(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        validateUrlOrKeystoreReference(url)
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/MicrosoftTeams.kt
@@ -5,8 +5,8 @@
 package org.opensearch.commons.notifications.model
 
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
+import org.opensearch.commons.notifications.validateUrlOrKeystoreReference
 import org.opensearch.commons.utils.logger
-import org.opensearch.commons.utils.validateUrl
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
@@ -26,7 +26,7 @@ data class MicrosoftTeams(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        validateUrlOrKeystoreReference(url)
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Slack.kt
@@ -5,8 +5,8 @@
 package org.opensearch.commons.notifications.model
 
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
+import org.opensearch.commons.notifications.validateUrlOrKeystoreReference
 import org.opensearch.commons.utils.logger
-import org.opensearch.commons.utils.validateUrl
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
@@ -26,7 +26,7 @@ data class Slack(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        validateUrlOrKeystoreReference(url)
     }
 
     companion object {

--- a/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
+++ b/src/main/kotlin/org/opensearch/commons/notifications/model/Webhook.kt
@@ -7,10 +7,10 @@ package org.opensearch.commons.notifications.model
 import org.opensearch.commons.notifications.NotificationConstants.HEADER_PARAMS_TAG
 import org.opensearch.commons.notifications.NotificationConstants.METHOD_TAG
 import org.opensearch.commons.notifications.NotificationConstants.URL_TAG
+import org.opensearch.commons.notifications.validateUrlOrKeystoreReference
 import org.opensearch.commons.utils.STRING_READER
 import org.opensearch.commons.utils.STRING_WRITER
 import org.opensearch.commons.utils.logger
-import org.opensearch.commons.utils.validateUrl
 import org.opensearch.core.common.Strings
 import org.opensearch.core.common.io.stream.StreamInput
 import org.opensearch.core.common.io.stream.StreamOutput
@@ -32,7 +32,7 @@ data class Webhook(
 
     init {
         require(!Strings.isNullOrEmpty(url)) { "URL is null or empty" }
-        validateUrl(url)
+        validateUrlOrKeystoreReference(url)
     }
 
     companion object {

--- a/src/test/kotlin/org/opensearch/commons/notifications/NotificationConfigReferenceTests.kt
+++ b/src/test/kotlin/org/opensearch/commons/notifications/NotificationConfigReferenceTests.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.commons.notifications
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.notifications.model.Chime
+import org.opensearch.commons.notifications.model.MicrosoftTeams
+import org.opensearch.commons.notifications.model.Slack
+import org.opensearch.commons.notifications.model.Webhook
+
+internal class NotificationConfigReferenceTests {
+    @Test
+    fun `notification URL models accept complete keystore references`() {
+        val reference = "\${keystore:webhook.url}"
+
+        assertDoesNotThrow {
+            Slack(reference)
+            Chime(reference)
+            MicrosoftTeams(reference)
+            Webhook(reference)
+        }
+    }
+
+    @Test
+    fun `ordinary HTTP URLs remain valid`() {
+        assertDoesNotThrow { validateUrlOrKeystoreReference("https://example.com/webhook") }
+    }
+
+    @Test
+    fun `embedded keystore references are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            validateUrlOrKeystoreReference("https://example.com/\${keystore:webhook.path}")
+        }
+    }
+
+    @Test
+    fun `malformed keystore references are rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            validateUrlOrKeystoreReference("\${keystore:webhook/path}")
+        }
+    }
+
+    @Test
+    fun `keystore reference matching requires the complete value`() {
+        assertTrue(isKeystoreReference("\${keystore:webhook.url}"))
+        assertFalse(isKeystoreReference("https://example.com/\${keystore:webhook.url}"))
+    }
+}


### PR DESCRIPTION
## Summary
- add notification-specific validation for complete `${keystore:<alias>}` URL references
- allow Slack, Chime, Microsoft Teams, and webhook models to store an unresolved URL reference
- reject embedded and malformed references while preserving ordinary HTTP and HTTPS URL validation

## Motivation
This is a prerequisite for https://github.com/opensearch-project/notifications/pull/1267. Allowing only whole-field references keeps secret URL material out of the notification system index and prevents an authorized configuration editor from redirecting an embedded secret to another host.

The generic `validateUrl` helper remains unchanged; the reference syntax is scoped to notification configuration models.

## Testing
- `./gradlew test`
- `./gradlew test --tests org.opensearch.commons.notifications.NotificationConfigReferenceTests ktlint`